### PR TITLE
fix: remove duplicate toast messages and add empty-file error handling

### DIFF
--- a/api/utils/csv_operation.go
+++ b/api/utils/csv_operation.go
@@ -44,6 +44,10 @@ func ValidateCSVFileFormat(fileName string) ([]Question, error) {
 		return questions, err
 	}
 
+	if len(csvData) == 0 {
+		return questions, fmt.Errorf("the uploaded file is empty. please choose a file with content")
+	}
+
 	if err := csvutil.Unmarshal(csvData, &questions); err != nil {
 		return questions, err
 	}

--- a/app/pages/admin/quiz/create-quiz.vue
+++ b/app/pages/admin/quiz/create-quiz.vue
@@ -38,8 +38,7 @@ const uploadQuizAndQuestions = async (e) => {
       onResponse({ response }) {
         if (response.status != 202) {
           requestPending.value = false;
-          toast.error("error while create quiz");
-          return;
+          throw new Error(response?._data?.data || "Error while creating quiz");
         }
         if (response.status == 202) {
           quizId.value = response._data?.data;


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. -->

## Fixes Issue

Closes #58 
Fixes incorrect error messages for unsupported and blank CSV uploads.

## Changes proposed
- [x] Added validation for **empty CSV files**
- [x] Removed duplicate toast messages on the frontend when API returns errors
- [x] Improved error handling logic to avoid showing multiple errors for a single failure


## Note to reviewers

- This PR ensures that users receive clear, friendly error messages  
  instead of raw backend responses (like 400/404).
- Duplicate toast issues are now resolved.
- Please verify both cases:
  1. Uploading an unsupported file type  
  2. Uploading an empty CSV file
