### PR TITLE
Fix : spelling of “Un-attempted” in quiz ranking screen

### DIFF
--- a/app/components/Quiz/StatisticsBadges.vue
+++ b/app/components/Quiz/StatisticsBadges.vue
@@ -15,7 +15,7 @@
       Total Incorrect: {{ props.userStatistics?.wrongAnwers }}
     </span>
     <span class="badge rounded-pill bg-light-secondary text-dark m-2 px-2 fs-5">
-      Total Un-attmpted: {{ props.userStatistics?.unAttemptedQuestions }}
+      Total Un-attempted: {{ props.userStatistics?.unAttemptedQuestions }}
     </span>
   </div>
 </template>


### PR DESCRIPTION
**Issue:**
Fixes spelling mistake in quiz ranking screen (#73)

**Problem:**
Currently, the quiz ranking screen displays the incorrect spelling "Un-attmpted", which looks unprofessional and may confuse users.

**What this PR does:**
Corrects the spelling to "Un-attempted" in the quiz ranking screen.

**Expected Result:**
Users see the correct and consistent text "Un-attempted" in the ranking screen.

**Notes:**
This is a UI-only change.
No backend logic or functionality is modified.