### PR TITLE
Fix : Improve create quiz form validation UX

### DIFF
--- a/app/pages/admin/quiz/create-quiz.vue
+++ b/app/pages/admin/quiz/create-quiz.vue
@@ -152,27 +152,14 @@ const imageFileUpload = async (e) => {
 <template>
   <!-- ImageUpload Modal -->
   <div v-if="requiredImage.length > 0">
-    <div
-      id="imageUpload"
-      class="modal fade"
-      tabindex="-1"
-      aria-labelledby="exampleModalLabel"
-      aria-hidden="true"
-    >
-      <div
-        class="modal-dialog modal-xl modal-dialog-scrollable modal-dialog-centered"
-      >
+    <div id="imageUpload" class="modal fade" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+      <div class="modal-dialog modal-xl modal-dialog-scrollable modal-dialog-centered">
         <div class="modal-content">
           <div class="modal-header">
             <h1 id="exampleModalLabel" class="modal-title fs-5">
               Questions Analysis
             </h1>
-            <button
-              type="button"
-              class="btn-close"
-              data-bs-dismiss="modal"
-              aria-label="Close"
-            ></button>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
           <div class="modal-body">
             <table class="table table-responsive">
@@ -187,32 +174,15 @@ const imageFileUpload = async (e) => {
                 <tr v-for="value in requiredImage" :key="value.question_id">
                   <td>{{ value.question }}</td>
                   <td>
-                    <v-file-input
-                      v-if="value.question_media == 'image'"
-                      id="image-attachment-question"
-                      prepend-icon="mdi-camera"
-                      type="file"
-                      class="form-control"
-                      :name="value.question_id"
-                      label="Question"
-                      accept="image/*"
-                      @change="imageFileUpload"
-                    >
+                    <v-file-input v-if="value.question_media == 'image'" id="image-attachment-question"
+                      prepend-icon="mdi-camera" type="file" class="form-control" :name="value.question_id"
+                      label="Question" accept="image/*" @change="imageFileUpload">
                     </v-file-input>
                   </td>
                   <td v-if="value.options_media == 'image'">
-                    <v-file-input
-                      v-for="index in 5"
-                      id="image-attachment-option"
-                      :key="index"
-                      :name="index + '_' + value.question_id"
-                      :label="'Option ' + index"
-                      prepend-icon="mdi-camera"
-                      type="file"
-                      class="form-control mb-2"
-                      accept="image/*"
-                      @change="imageFileUpload"
-                    >
+                    <v-file-input v-for="index in 5" id="image-attachment-option" :key="index"
+                      :name="index + '_' + value.question_id" :label="'Option ' + index" prepend-icon="mdi-camera"
+                      type="file" class="form-control mb-2" accept="image/*" @change="imageFileUpload">
                     </v-file-input>
                   </td>
                 </tr>
@@ -220,19 +190,10 @@ const imageFileUpload = async (e) => {
             </table>
           </div>
           <div class="modal-footer text-white">
-            <button
-              v-if="imageRequestPending"
-              type="button"
-              class="btn btn-secondary"
-            >
+            <button v-if="imageRequestPending" type="button" class="btn btn-secondary">
               Pending...
             </button>
-            <button
-              v-else
-              type="button"
-              class="btn btn-secondary"
-              data-bs-dismiss="modal"
-            >
+            <button v-else type="button" class="btn btn-secondary" data-bs-dismiss="modal">
               Close
             </button>
           </div>
@@ -241,56 +202,30 @@ const imageFileUpload = async (e) => {
     </div>
   </div>
 
-  <Frame
-    page-title="Create Quiz"
-    page-message="Create New Quiz By Uploading CSV"
-  >
+  <Frame page-title="Create Quiz" page-message="Create New Quiz By Uploading CSV">
     <form @submit="uploadQuizAndQuestions">
       <div class="mb-3">
         <div class="mb-3">
-          <label for="title" class="form-label">Quiz Title</label>
-          <input
-            id="title"
-            v-model="title"
-            type="text"
-            class="form-control"
-            name="title"
-            aria-describedby="helpId"
-            placeholder=""
-            required
-          />
-          <small v-if="title == ''" id="helpId" class="form-text text-danger"
-            >Required</small
-          >
+          <label for="title" class="form-label">Quiz Title
+            <small v-if="title == ''" id="helpId" class="form-text text-danger">*</small>
+          </label>
+          <input id="title" v-model="title" type="text" class="form-control" name="title" aria-describedby="helpId"
+            placeholder="" required />
+
         </div>
         <div class="mb-3">
           <label for="description" class="form-label">Quiz Description</label>
-          <input
-            id="description"
-            type="text"
-            class="form-control"
-            name="description"
-            aria-describedby="helpId"
-            placeholder=""
-            required
-          />
+          <input id="description" type="text" class="form-control" name="description" aria-describedby="helpId"
+            placeholder="" required />
           <!-- <small id="helpId" class="form-text text-muted">Help text</small> -->
         </div>
         <div class="mb-3">
-          <label for="attachment" class="form-label">Choose File</label>
-          <input
-            id="attachment"
-            type="file"
-            class="form-control"
-            name="attachment"
-            placeholder="upload"
-            aria-describedby="fileHelpId"
-            accept=".csv"
-            @change="(e) => (file = e.target.files.length)"
-          />
-          <div v-if="file == 0" id="fileHelpId" class="form-text text-danger">
-            Required
-          </div>
+          <label for="attachment" class="form-label">Choose File
+            <small v-if="file == 0" id="fileHelpId" class="form-text text-danger">*</small>
+          </label>
+          <input id="attachment" type="file" class="form-control" name="attachment" placeholder="upload"
+            aria-describedby="fileHelpId" accept=".csv" @change="(e) => (file = e.target.files.length)" />
+
         </div>
       </div>
       <div class="d-flex p-2">
@@ -300,19 +235,9 @@ const imageFileUpload = async (e) => {
         <button v-else type="submit" class="btn text-white btn-primary me-2">
           Create Quiz
         </button>
-        <a
-          class="btn btn-primary me-2"
-          href="/files/demo.csv"
-          download="demo.csv"
-          >Download Sample</a
-        >
-        <div
-          v-if="requiredImage.length > 0"
-          data-bs-toggle="modal"
-          :data-bs-target="`#imageUpload`"
-          type="button"
-          class="btn text-white btn-primary me-2"
-        >
+        <a class="btn btn-primary me-2" href="/files/demo.csv" download="demo.csv">Download Sample</a>
+        <div v-if="requiredImage.length > 0" data-bs-toggle="modal" :data-bs-target="`#imageUpload`" type="button"
+          class="btn text-white btn-primary me-2">
           Upload Images
         </div>
         <UtilsStartQuiz v-if="quizId && !requestPending" :quiz-id="quizId" />


### PR DESCRIPTION
**Issue:**
Fixes premature validation messages in create quiz form (#69)

**Problem:**
Currently, when the user opens the create quiz popup, “Required” messages are displayed for the quiz title and file upload fields before any user interaction. This creates unnecessary visual noise and a confusing first impression.

**What this PR does:**
- Hides “required” validation messages on initial render.
- Displays a visual indicator (*) for required fields.

**Expected Result:**
Users see a clean create quiz form, making the form easier and less distracting to use.

**<img width="879" height="477" alt="Screenshot From 2025-12-29 13-56-35" src="https://github.com/user-attachments/assets/ccade8ba-493e-4fee-91e4-c014baafb070" />**
Changes are limited to frontend.