### PR TITLE
Feat : Improve forgot password confirmation message styling

### DIFF
--- a/app/pages/recovery.vue
+++ b/app/pages/recovery.vue
@@ -11,6 +11,7 @@
               <img class="logo" src="/jovvix-logo.png" alt="" />
             </NuxtLink>
             <h3 class="mt-3 welcome-text">Recover your account</h3>
+            <p class="mt-3 welcome-text">If an account exists for this email address, you will receive a password recovery email shortly.</p>
           </div>
 
           <form @submit.prevent="verifyOTP">


### PR DESCRIPTION
**Issue:**
Clarify forgot password OTP message for non-existing emails (#54)

**Problem:**
Currently, when a user submits the forgot password form, an OTP email is sent (or appears to be sent) regardless of whether the email exists. This can confuse users, as they may expect an error when the email is not registered.

**What this PR does:**
- Adds a neutral confirmation message after submitting the forgot password form
- Clearly informs users that an OTP will be sent only if the email exists
- Preserves security by avoiding email existence disclosure

**Expected Result:**
Users receive a clear and reassuring message after submitting the forgot password form, reducing confusion while maintaining email enumeration security.

<img width="1219" height="595" alt="Screenshot From 2025-12-31 10-06-29" src="https://github.com/user-attachments/assets/3ee8a0d7-8430-4357-889c-68a300d61e5a" />

