### PR TITLE
Fix : handle expired registration flow with friendly message

### DIFF
--- a/app/pages/account/register.vue
+++ b/app/pages/account/register.vue
@@ -55,6 +55,10 @@ console.log(); // this console.log is required because without this, nuxt will g
           onResponse({ response }) {
             response?._data?.ui?.messages?.forEach((message) => {
               if (message.type === "error") {
+                if (message.text?.toLowerCase().includes("expired")) {
+                  toast.error("Your session has expired. Please start the registration process again.");
+                  return; 
+                }
                 if (message.id === 4000007) {
                   toast.error("An account with the same email exists already!");
                 } else {
@@ -133,66 +137,30 @@ async function setFlowIDAndCSRFToken() {
 
 <template>
   <QuizLoadingSpace v-if="component === 'waiting'"></QuizLoadingSpace>
-  <Frame
-    v-else
-    page-title="Register"
-    page-message="We Would Be Happy To Have You"
-  >
-    <form
-      method="POST"
-      :action="registerURLWithFlowQuery"
-      enctype="application/json"
-    >
+  <Frame v-else page-title="Register" page-message="We Would Be Happy To Have You">
+    <form method="POST" :action="registerURLWithFlowQuery" enctype="application/json">
       <div class="mb-3">
         <label for="firstname" class="form-label">First Name</label>
-        <input
-          id="firstname"
-          v-model="firstname"
-          type="text"
-          name="traits.name.first"
-          class="form-control"
-          required
-        />
+        <input id="firstname" v-model="firstname" type="text" name="traits.name.first" class="form-control" required />
         <div v-if="errors.firstname" class="text-danger">
           {{ errors.firstname }}
         </div>
       </div>
       <div class="mb-3">
         <label for="lastname" class="form-label">Last Name</label>
-        <input
-          id="lastname"
-          v-model="lastname"
-          type="text"
-          name="traits.name.last"
-          class="form-control"
-          required
-        />
+        <input id="lastname" v-model="lastname" type="text" name="traits.name.last" class="form-control" required />
         <div v-if="errors.lastname" class="text-danger">
           {{ errors.lastname }}
         </div>
       </div>
       <div class="mb-3">
         <label for="traits.email" class="form-label">Email</label>
-        <input
-          id="email"
-          v-model="email"
-          type="email"
-          name="traits.email"
-          class="form-control"
-          required
-        />
+        <input id="email" v-model="email" type="email" name="traits.email" class="form-control" required />
         <div v-if="errors.email" class="text-danger">{{ errors.email }}</div>
       </div>
       <div class="mb-3">
         <label for="password" class="form-label">Password</label>
-        <input
-          id="password"
-          v-model="password"
-          type="password"
-          name="password"
-          class="form-control"
-          required
-        />
+        <input id="password" v-model="password" type="password" name="password" class="form-control" required />
         <div v-if="errors.password" class="text-danger">
           {{ errors.password }}
         </div>


### PR DESCRIPTION
**Issue:**
Handle expired Ory Kratos registration flows (#57)

**Problem:**
When the user delays during registration, Kratos returns a backend error like:
"The registration flow expired 1.23 minutes ago".
Currently, the frontend displays this raw error message directly, which is confusing and unfriendly to users.

**What this PR does:**
- Adds explicit detection for expired registration flows returned from Kratos.
- Shows a user-friendly warning toast instead of the raw backend error text.
- Prevents duplicate or confusing error messages in the UI.
- Keeps existing 410 flow recovery logic unchanged, so the registration flow still automatically restarts if needed.

**Expected Result:**
Users see a clear, friendly message when the registration flow expires, rather than a raw backend error, improving UX without changing backend behavior.

<img width="1885" height="448" alt="Screenshot From 2025-12-31 10-47-35" src="https://github.com/user-attachments/assets/6333fc72-69f5-4844-9d90-027bf1458aae" />
