### PR TITLE
Fix : show proper validation messages for invalid or empty file uploads

### DIFF
--- a/api/constants/constant.go
+++ b/api/constants/constant.go
@@ -117,6 +117,8 @@ const (
 	ErrSingleAnswerLength       = "in single answer there should be only one correct answer"
 	ErrQuestionType             = "please provide a proper question type"
 	ErrQuestionId               = "question type id not exists"
+	ErrEmptyFile 				= "The uploaded file is empty. Please choose a file with content."
+    ErrUnsupportedFileType 		= "The uploaded file is not a valid CSV. Please check the format and try again."
 
 	// quiz-id
 	QuizId       = "quiz_id"

--- a/api/middlewares/csv_auth.go
+++ b/api/middlewares/csv_auth.go
@@ -21,7 +21,6 @@ func (m *Middleware) ValidateCsv(c *fiber.Ctx) error {
 		return utils.JSONFail(c, http.StatusBadRequest, constants.ErrGettingAttachment)
 	}
 
-	// size validation
 	if file.Size > constants.FileSize {
 		m.Logger.Error("error in getting csv file", zap.Error(err))
 		return utils.JSONFail(c, http.StatusBadRequest, constants.ErrGettingAttachment)
@@ -34,17 +33,15 @@ func (m *Middleware) ValidateCsv(c *fiber.Ctx) error {
 	}
 
 	for _, types := range allowedTypes {
-
 		if types == file.Header.Get("Content-Type") {
 			isMatched = true
 			break
 		}
 	}
 
-	// content type validation
 	if !isMatched {
 		m.Logger.Error("file type mismatch", zap.Any("file", file))
-		return utils.JSONFail(c, fiber.StatusBadRequest, constants.ErrFileIsNotInSupportedType)
+		return utils.JSONFail(c, fiber.StatusBadRequest, constants.ErrUnsupportedFileType)
 	}
 
 	folder := "./uploads"

--- a/api/utils/csv_operation.go
+++ b/api/utils/csv_operation.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Improwised/jovvix/api/constants"
 	"github.com/Improwised/jovvix/api/models"
 	"github.com/google/uuid"
 	"github.com/jszwec/csvutil"
@@ -46,6 +47,10 @@ func ValidateCSVFileFormat(fileName string) ([]Question, error) {
 
 	if err := csvutil.Unmarshal(csvData, &questions); err != nil {
 		return questions, err
+	}
+
+	if len(questions) == 0 {
+		return questions, fmt.Errorf(constants.ErrEmptyFile)
 	}
 
 	return questions, nil

--- a/app/pages/admin/quiz/create-quiz.vue
+++ b/app/pages/admin/quiz/create-quiz.vue
@@ -35,22 +35,18 @@ const uploadQuizAndQuestions = async (e) => {
       body: formData,
       mode: "cors",
       credentials: "include",
-      onResponse({ response }) {
-        if (response.status != 202) {
-          requestPending.value = false;
-          toast.error("error while create quiz");
-          return;
-        }
-        if (response.status == 202) {
-          quizId.value = response._data?.data;
-          toast.success(app.$CsvUploadSuccess);
-        }
-      },
+        onResponse({ response }) {
+          if (response.status === 202) {
+            quizId.value = response._data?.data;
+            toast.success(app.$CsvUploadSuccess);
+          }
+        },
     });
   } catch (error) {
-    toast.error(error.message);
-    requestPending.value = false;
-    return;
+      const parsed = error?.data?.data ?? error?.data?.message ?? error?.message ?? JSON.stringify(error)
+      toast.error(parsed || "error while creating quiz")
+      requestPending.value = false
+      return
   }
 
   try {


### PR DESCRIPTION
**Issue:**
Incorrect error handling for unsupported and empty file uploads (#58)

**Problem:**
Currently, when a user uploads a file that is either in an unsupported format or is blank, the application returns generic 400 or 404 errors. This results in unclear feedback for users, who are not informed why their upload failed or how to fix it.

**What this PR does:**
- Adds proper validation for unsupported file formats
- Detects and handles empty file uploads
- Displays clear, user-friendly error messages instead of generic HTTP errors

**Expected Result:**
Users receive meaningful validation messages when uploading unsupported or empty files, making the upload experience clearer and reducing confusion caused by generic error responses.

<img width="1903" height="616" alt="Screenshot From 2026-01-01 14-25-39" src="https://github.com/user-attachments/assets/a180015b-07f9-4eec-b1ba-8cc53d649cc5" />
<img width="1903" height="616" alt="Screenshot From 2026-01-01 14-26-04" src="https://github.com/user-attachments/assets/f22fcbdb-fb83-43d4-ac10-3db014c7239e" />
