### PR TITLE
fix : sync question timer with server start time

### DIFF
--- a/api/controllers/api/v1/question_controller.go
+++ b/api/controllers/api/v1/question_controller.go
@@ -126,12 +126,8 @@ func (ctrl *QuestionController) GetQuestionById(c *fiber.Ctx) error {
 			question.Options[key] = presignedURL
 		}
 	}
-	questionStartTime := time.Now()
 	ctrl.logger.Debug("QuestionController.GetQuestionById success", zap.Any("question", question))
-	return utils.JSONSuccess(c, http.StatusOK, map[string]interface{}{
-        "question":   question,
-        "start_time": questionStartTime,
-    })
+	return utils.JSONSuccess(c, http.StatusOK, question)
 }
 
 // UpdateQuestionById to update question and thier options with answer.

--- a/app/components/Quiz/QuestionSpace.vue
+++ b/app/components/Quiz/QuestionSpace.vue
@@ -73,10 +73,8 @@ function handleEvent(message) {
   }
   if (message.event == app.$GetQuestion) {
     question.value = message.data;
-    serverStartTime.value = message.data.start_time
-    ? new Date(message.data.start_time)
-    : new Date();
-
+    serverStartTime.value = new Date(message.data.start_time)
+    time.value = 0;
     count.value = null;
     answer.value = [];
 
@@ -95,22 +93,20 @@ function handleEvent(message) {
 function handleTimer() {
   clearInterval(timer.value);
 
-  const duration = question.value.duration;
-
+  const duration = Number(question.value.duration);
 
   timer.value = setInterval(() => {
     const now = new Date();
 
     const elapsedSeconds = Math.floor(
-      (now - serverStartTime.value) / 1000
+      (now.getTime() - serverStartTime.value.getTime()) / 1000
     );
 
-    time.value = elapsedSeconds;
+    time.value =  Math.min(Math.max(elapsedSeconds, 0), duration);  ;
 
     if (elapsedSeconds >= duration) {
       clearInterval(timer.value);
       timer.value = null;
-      time.value = duration;
     }
   }, 1000);
 }


### PR DESCRIPTION
**Issue:**
Question timer was calculated purely on the client side, causing timer mismatch when users joined late or experienced network delays. (#60)

**Problem:**
Since the timer started locally on each client, different users saw different remaining durations for the same question. This resulted in timer desynchronization between admin and participants.

**What this PR does:**
This PR updates the question flow to use the server-provided question start time and calculates the remaining duration on the frontend based on that value. This ensures all users see a synchronized and accurate question timer, regardless of when they receive the question.