### PR TITLE
Fix: prevent quiz timer drift by deriving duration

### DIFF
--- a/api/controllers/api/v1/quiz_socket_controller.go
+++ b/api/controllers/api/v1/quiz_socket_controller.go
@@ -1006,13 +1006,10 @@ func sendSingleQuestion(c *websocket.Conn, qc *quizSocketController, wg *sync.Wa
 		"totalQuestions": totalQuestions,
 		"totalJoinUser":  totalUserJoin,
 	}
-
+	response.Data = responseData
 	if !lastQuestionTimeStamp.Valid { // handling new question
-		response.Data = responseData
 		shareEvenWithUser(c, qc, response, constants.EventSendQuestion, session.ID.String(), int(session.InvitationCode.Int32), constants.ToAll, arrangeMu)
 	} else { // handling running question
-		responseData["duration"] = question.DurationInSeconds - int(time.Since(lastQuestionTimeStamp.Time).Seconds())
-		response.Data = responseData
 		shareEvenWithUser(c, qc, response, constants.EventSendQuestion, session.ID.String(), int(session.InvitationCode.Int32), constants.ToAdmin, arrangeMu)
 	}
 


### PR DESCRIPTION
**Description :**
- Fixes quiz timing logic by making the backend send only the question start_time. 
- The backend no longer reduces duration dynamically; remaining time is now derived on the frontend using the provided start time. This removes timer drift and ensures consistent behavior for reconnecting and mid-question clients.