### PR TITLE
Fix: persist last component before admin exit in localstorage.

### DIFF
--- a/app/components/utils/StartQuiz.vue
+++ b/app/components/utils/StartQuiz.vue
@@ -49,7 +49,7 @@ const handleStartDemo = async () => {
   }
 
   removeAllUsers();
-
+  setSocketObject(null);
   router.push(`/admin/arrange/${activeQuizId.value}`);
 
   // add session in store after 1 second

--- a/app/composables/admin_operation.js
+++ b/app/composables/admin_operation.js
@@ -94,6 +94,7 @@ export default class AdminOperations extends QuizHandler {
     console.log("stoping ping of admin");
     this.stopPing();
     super.onClose(event);
+    setSocketObject(null);
   }
 
   requestPauseQuiz(isPause) {

--- a/app/composables/quiz_operation.js
+++ b/app/composables/quiz_operation.js
@@ -40,9 +40,11 @@ export default class QuizHandler {
     this.socket.onclose = (event) => this.onClose(event);
     this.socket.onmessage = (event) => this.onMessage(event);
     this.close = (code) => this.socket.close(code);
+    setSocketObject(this.socket);
   }
 
   continue() {
+    this.socket = socketObject;
     this.socket.onopen = (event) => this.onOpen(event);
     this.socket.onerror = (event) => this.onError(event);
     this.socket.onclose = (event) => this.onClose(event);

--- a/app/composables/stored_socket.js
+++ b/app/composables/stored_socket.js
@@ -1,0 +1,7 @@
+let socketObject = null;
+
+const setSocketObject = (data) => {
+  socketObject = data;
+};
+
+export { socketObject, setSocketObject };

--- a/app/store/session.js
+++ b/app/store/session.js
@@ -3,6 +3,7 @@ export const useSessionStore = defineStore(
   "session-store",
   () => {
     const session = ref(false);
+    const lastComponent = ref("");
 
     const getSession = () => {
       return session.value;
@@ -12,7 +13,22 @@ export const useSessionStore = defineStore(
       session.value = data;
     };
 
-    return { session, getSession, setSession };
+    const getLastComponent = () => {
+      return lastComponent.value;
+    };
+
+    const setLastComponent = (data) => {
+      lastComponent.value = data;
+    };
+
+    return {
+      session,
+      getSession,
+      setSession,
+      lastComponent,
+      getLastComponent,
+      setLastComponent,
+    };
   },
   {
     persist: true,


### PR DESCRIPTION
**Issue:**
When an admin leaves the waiting lobby and later navigates back using “Your quiz is still running… check it out!”, the page sometimes remains stuck in an infinite loading state.(#62)

**Problem:**
The admin UI was fully dependent on real-time socket events to determine which component should be rendered.

On reconnect or navigation back to the waiting lobby:
- If no new socket event occurs (e.g., no user joins/leaves),
- The backend does not resend the current session state,
- The frontend never receives a state update,
- The UI remains stuck on the loading screen until a new event happens or the page is refreshed.
- This created a state desynchronization issue between backend session state and frontend UI state.

**What This PR Does:**
- Fixes infinite loading when admin navigates away and returns to quiz.
- Stores last rendered component state on unmount.
- On mount, if socket exists and last component is not "Waiting", it continues the existing admin session.
- If last component was "Waiting" (or no socket exists), it creates a fresh admin connection.
- Ensures correct reconnect behavior and prevents stuck loading state.