### PR TITLE
fix: reuse active quiz session when quiz is already running

### DIFF
--- a/api/controllers/api/v1/quiz_controller.go
+++ b/api/controllers/api/v1/quiz_controller.go
@@ -302,6 +302,15 @@ func (ctrl *QuizController) GenerateDemoSession(c *fiber.Ctx) error {
 	quizId := c.Params(constants.QuizId)
 	userId := quizUtilsHelper.GetString(c.Locals(constants.ContextUid))
 
+	activeQuiz, err := ctrl.activeQuizModel.GetActiveQuizByQuizIDAndAdminID(quizId, userId)
+	if err == nil {
+		return utils.JSONSuccess(c, http.StatusAccepted, activeQuiz.ID)
+	}
+	if err != sql.ErrNoRows {
+		ctrl.logger.Error("error checking active demo session", zap.Error(err))
+		return utils.JSONError(c, http.StatusInternalServerError, err.Error())
+	}
+
 	sessionId, err := ctrl.activeQuizModel.CreateActiveQuiz("demo session", quizId, userId, sql.NullTime{}, sql.NullTime{})
 
 	if err != nil {

--- a/api/models/active_quizzes.go
+++ b/api/models/active_quizzes.go
@@ -104,6 +104,26 @@ func (model *ActiveQuizModel) GetSessionByCode(invitationCode string) (ActiveQui
 	return activeQuiz, nil
 }
 
+func (model *ActiveQuizModel) GetActiveQuizByQuizIDAndAdminID(quizID string, adminID string) (ActiveQuiz, error) {
+	var activeQuiz ActiveQuiz = ActiveQuiz{}
+
+	found, err := model.db.Select("*").From(ActiveQuizzesTable).Where(
+		goqu.I("quiz_id").Eq(quizID),
+		goqu.I("admin_id").Eq(adminID),
+		goqu.I("is_active").Eq(true),
+	).Order(goqu.I("updated_at").Desc()).Limit(1).ScanStruct(&activeQuiz)
+
+	if err != nil {
+		return activeQuiz, err
+	}
+
+	if !found {
+		return activeQuiz, sql.ErrNoRows
+	}
+
+	return activeQuiz, nil
+}
+
 func (model *ActiveQuizModel) GetQuestionsCopy(activeQuizId uuid.UUID, quizId string) error {
 
 	// Walk the next_question chain so playback honors admin-defined order.


### PR DESCRIPTION
**Task:** 
Prevent duplicate active quiz sessions when restarting an already running quiz. (https://station.improwised.com/epp/tasks/view/kanban?view=1#IP-101)

## Code changes
- Added a new backend model method to find an active quiz session by `quiz_id`, `admin_id`, and `is_active = true`.
- Updated `GenerateDemoSession` to check for an existing active session before creating a new demo session.
- If an active session already exists, the API now returns the existing `active_quiz_id`.
- If no active session exists, the API continues with the old flow and creates a new demo session.
- No frontend change was needed because the frontend already redirects using the `active_quiz_id` returned by the API.