### PR TITLE
feat: rebuild share quiz permission modal in new theme

### DIFF
--- a/app/components/Quiz/ShareQuizAuthorizeUser.vue
+++ b/app/components/Quiz/ShareQuizAuthorizeUser.vue
@@ -1,0 +1,89 @@
+<script setup>
+import { Pencil, Trash2 } from "lucide-vue-next";
+
+const props = defineProps({
+  user: {
+    type: Object,
+    required: true,
+    default: () => {
+      return {};
+    },
+  },
+});
+
+const emits = defineEmits(["showEditForm", "deleteUserPermission"]);
+
+// open the edit form to change this user's permission for the quiz
+const showEditForm = () => {
+  emits(
+    "showEditForm",
+    props.user.id,
+    props.user.shared_to,
+    props.user.permission
+  );
+};
+</script>
+
+<template>
+  <div
+    class="flex items-center justify-between gap-3 jv-border-rough border-[2px] border-jv-ink bg-jv-white px-3 py-3 shadow-brutal-sm"
+  >
+    <!-- User identity -->
+    <div class="flex min-w-0 flex-1 items-center gap-3">
+      <span class="relative shrink-0">
+        <img
+          src="https://api.dicebear.com/9.x/bottts/svg?seed=Jade"
+          alt="User avatar"
+          class="size-10 rounded-full border-[2px] border-jv-ink bg-jv-canvas"
+          width="40"
+          height="40"
+        />
+        <span
+          class="absolute bottom-0 right-0 size-3 rounded-full border-2 border-jv-white bg-jv-accent-green"
+          aria-hidden="true"
+        ></span>
+      </span>
+
+      <div class="min-w-0 flex-1">
+        <h4
+          v-if="props.user.first_name?.Valid"
+          class="truncate text-[15px] font-black text-jv-ink"
+        >
+          {{ props.user.first_name.String }}
+          {{ props.user.last_name?.String }}
+        </h4>
+        <h4 v-else class="text-[15px] font-black text-jv-ink">Unknown</h4>
+        <div class="truncate text-[13px] font-semibold text-jv-muted">
+          {{ props.user.shared_to }}
+        </div>
+      </div>
+    </div>
+
+    <!-- Permission + actions -->
+    <div class="flex shrink-0 items-center gap-2">
+      <span
+        class="rounded-full border-[2px] border-jv-ink bg-jv-yellow px-2.5 py-1 text-[12px] font-black uppercase tracking-[0.08em] text-jv-ink"
+      >
+        {{ props.user.permission }}
+      </span>
+      <button
+        type="button"
+        title="Edit Permission"
+        aria-label="Edit permission"
+        class="grid size-8 place-items-center rounded-[8px] border-[2px] border-jv-ink bg-jv-white text-jv-ink shadow-brutal-sm transition-transform hover:-rotate-[3deg] active:translate-x-[1px] active:translate-y-[1px] active:shadow-none"
+        @click="showEditForm"
+      >
+        <Pencil class="size-4" :stroke-width="2.4" />
+      </button>
+      <button
+        type="button"
+        title="Delete Permission"
+        aria-label="Delete permission"
+        class="grid size-8 place-items-center rounded-[8px] border-[2px] border-jv-ink bg-jv-coral text-white shadow-brutal-sm transition-transform hover:rotate-[3deg] active:translate-x-[1px] active:translate-y-[1px] active:shadow-none"
+        @click="emits('deleteUserPermission', props.user.id)"
+      >
+        <Trash2 class="size-4" :stroke-width="2.4" />
+      </button>
+    </div>
+  </div>
+</template>

--- a/app/components/Quiz/ShareQuizForm.vue
+++ b/app/components/Quiz/ShareQuizForm.vue
@@ -1,0 +1,117 @@
+<script setup>
+import { ref, watch } from "vue";
+import { Send, UserCog } from "lucide-vue-next";
+
+const props = defineProps({
+  formTitle: {
+    type: String,
+    required: true,
+    default: "",
+  },
+  id: {
+    type: String,
+    required: false,
+    default: "",
+  },
+  email: {
+    type: String,
+    required: false,
+    default: "",
+  },
+  permission: {
+    type: String,
+    required: false,
+    default: "",
+  },
+});
+
+const emits = defineEmits(["shareQuiz", "updateUserPermission"]);
+
+const email = ref(props.email);
+const permission = ref(props.permission);
+
+// Keep local state in sync when editing an existing permission
+watch(
+  () => props.email,
+  (newEmail) => {
+    email.value = newEmail;
+  }
+);
+
+watch(
+  () => props.permission,
+  (newPermission) => {
+    permission.value = newPermission;
+  }
+);
+
+const handleSubmit = () => {
+  if (props.id) {
+    emits("updateUserPermission", props.id, email.value, permission.value);
+  } else {
+    emits("shareQuiz", email.value, permission.value);
+  }
+
+  email.value = "";
+  permission.value = "";
+};
+</script>
+
+<template>
+  <form
+    class="mt-2 jv-border-rough border-[3px] border-jv-ink bg-jv-canvas p-4 shadow-brutal-sm sm:p-5"
+    @submit.prevent="handleSubmit"
+  >
+    <h3
+      class="mb-4 flex items-center gap-2 font-body text-[15px] font-black uppercase tracking-[0.14em] text-jv-ink"
+    >
+      <UserCog class="size-4" :stroke-width="2.6" />
+      {{ props.formTitle }}
+    </h3>
+
+    <!-- Email -->
+    <label class="mb-3 grid gap-2">
+      <span
+        class="text-[12px] font-black uppercase tracking-[0.16em] text-jv-ink"
+      >
+        Email <span class="text-jv-coral">*</span>
+      </span>
+      <input
+        v-model="email"
+        type="email"
+        name="identifier"
+        required
+        :disabled="props.id !== ''"
+        class="h-12 border-[3px] border-jv-ink bg-jv-white px-3 text-[15px] font-semibold text-jv-ink outline-none transition-shadow focus:shadow-brutal-sm disabled:cursor-not-allowed disabled:opacity-60"
+      />
+    </label>
+
+    <!-- Permission -->
+    <label class="mb-4 grid gap-2">
+      <span
+        class="text-[12px] font-black uppercase tracking-[0.16em] text-jv-ink"
+      >
+        Permission <span class="text-jv-coral">*</span>
+      </span>
+      <select
+        v-model="permission"
+        required
+        class="h-12 border-[3px] border-jv-ink bg-jv-white px-3 text-[15px] font-semibold text-jv-ink outline-none transition-shadow focus:shadow-brutal-sm"
+      >
+        <option value="" disabled>Select permission level</option>
+        <option value="read">Read</option>
+        <option value="write">Write</option>
+        <option value="share">Share</option>
+      </select>
+    </label>
+
+    <!-- Submit -->
+    <button
+      type="submit"
+      class="inline-flex h-11 w-full items-center justify-center gap-2 rounded-full border-[2px] border-jv-ink bg-jv-coral px-5 font-body text-[15px] font-black text-white shadow-brutal-sm transition-transform hover:rotate-[1deg] active:translate-x-[2px] active:translate-y-[2px] active:shadow-none"
+    >
+      <Send class="size-4" :stroke-width="2.4" />
+      {{ props.id ? "Update Access" : "Share Quiz" }}
+    </button>
+  </form>
+</template>

--- a/app/components/Quiz/ShareQuizModal.vue
+++ b/app/components/Quiz/ShareQuizModal.vue
@@ -1,0 +1,223 @@
+<script setup>
+import { computed, ref, watch } from "vue";
+import { usePush } from "notivue";
+import { UserPlus, Users } from "lucide-vue-next";
+import { Modal } from "@/components/ui/modal";
+import ShareQuizAuthorizeUser from "./ShareQuizAuthorizeUser.vue";
+import ShareQuizForm from "./ShareQuizForm.vue";
+
+const props = defineProps({
+  modelValue: {
+    type: Boolean,
+    default: false,
+  },
+  quizId: {
+    type: String,
+    required: true,
+    default: "",
+  },
+});
+
+const emits = defineEmits(["update:modelValue"]);
+
+const toast = usePush();
+const url = useRuntimeConfig().public;
+const headers = useRequestHeaders(["cookie"]);
+
+// edit-form state
+const id = ref("");
+const email = ref("");
+const permission = ref("");
+const component = ref("");
+
+// Authorized users for this quiz — reactive to quizId so the modal works
+// from both the quiz-detail page and the per-quiz list cards.
+const {
+  refresh: quizAuthorizedUsersDataRefresh,
+  data: quizAuthorizedUsersData,
+  pending: quizAuthorizedUsersPending,
+  error: quizAuthorizedUsersError,
+} = useFetch(() => `${url.apiUrl}/shared_quizzes/${props.quizId}`, {
+  method: "GET",
+  headers,
+  mode: "cors",
+  credentials: "include",
+  immediate: false,
+  watch: [() => props.quizId],
+});
+
+const authorizedUsers = computed(
+  () => quizAuthorizedUsersData.value?.data || []
+);
+
+function close() {
+  emits("update:modelValue", false);
+}
+
+// Reset the form whenever the modal opens, and (re)load the user list.
+watch(
+  () => props.modelValue,
+  (open) => {
+    if (open) {
+      component.value = "";
+      id.value = "";
+      email.value = "";
+      permission.value = "";
+      if (props.quizId) quizAuthorizedUsersDataRefresh();
+    }
+  }
+);
+
+const showEditForm = (idVal, emailVal, permissionVal) => {
+  id.value = idVal;
+  email.value = emailVal;
+  permission.value = permissionVal;
+  component.value = "edit-permission";
+};
+
+const shareQuiz = async (emailVal, permissionVal) => {
+  try {
+    await $fetch(`${url.apiUrl}/shared_quizzes/${props.quizId}`, {
+      method: "POST",
+      headers,
+      body: { email: emailVal, permission: permissionVal },
+      credentials: "include",
+    });
+    toast.success("Quiz shared successfully!");
+    quizAuthorizedUsersDataRefresh();
+    component.value = "";
+  } catch (error) {
+    console.error("Failed to share the quiz.", error);
+    toast.error("Failed to share the quiz.");
+  }
+};
+
+const updateUserPermission = async (idVal, emailVal, permissionVal) => {
+  try {
+    await $fetch(
+      `${url.apiUrl}/shared_quizzes/${props.quizId}?shared_quiz_id=${idVal}`,
+      {
+        method: "PUT",
+        headers,
+        body: { email: emailVal, permission: permissionVal },
+        credentials: "include",
+      }
+    );
+    toast.success("User permission updated successfully!");
+    quizAuthorizedUsersDataRefresh();
+    component.value = "";
+  } catch (error) {
+    console.error("Failed to update user permission.", error);
+    toast.error("Failed to update user permission.");
+  }
+};
+
+const deleteUserPermission = async (idVal) => {
+  try {
+    await $fetch(
+      `${url.apiUrl}/shared_quizzes/${props.quizId}?shared_quiz_id=${idVal}`,
+      {
+        method: "DELETE",
+        headers,
+        credentials: "include",
+      }
+    );
+    toast.success("User permission deleted successfully!");
+    quizAuthorizedUsersDataRefresh();
+  } catch (error) {
+    console.error("Failed to delete user permission.", error);
+    toast.error("Failed to delete user permission.");
+  }
+};
+</script>
+
+<template>
+  <Modal
+    :model-value="props.modelValue"
+    title="Share Quiz"
+    description="Give people access to this quiz and manage their permissions."
+    size="md"
+    @update:model-value="emits('update:modelValue', $event)"
+  >
+    <div
+      class="mb-4 h-[3px] w-full rounded-full border-b-[3px] border-dashed border-jv-ink/30"
+      aria-hidden="true"
+    ></div>
+
+    <div v-if="quizAuthorizedUsersPending" class="py-6 text-center">
+      <p class="text-[15px] font-semibold text-jv-muted">Loading...</p>
+    </div>
+
+    <div
+      v-else-if="quizAuthorizedUsersError"
+      class="jv-border-rough border-[2px] border-jv-ink bg-jv-white p-4 text-[15px] font-semibold text-jv-coral"
+    >
+      {{ quizAuthorizedUsersError.message || quizAuthorizedUsersError }}
+    </div>
+
+    <template v-else>
+      <!-- People with access -->
+      <div class="flex items-center justify-between gap-3">
+        <h3
+          class="flex items-center gap-2 font-body text-[15px] font-black uppercase tracking-[0.14em] text-jv-ink"
+        >
+          <Users class="size-4" :stroke-width="2.6" />
+          People with access
+        </h3>
+        <button
+          type="button"
+          title="Add People"
+          aria-label="Add people"
+          class="inline-flex items-center gap-2 rounded-full border-[2px] border-jv-ink bg-jv-white px-3 py-1.5 text-[13px] font-black text-jv-ink shadow-brutal-sm transition-transform hover:-rotate-[2deg] active:translate-x-[1px] active:translate-y-[1px] active:shadow-none"
+          @click="component = 'give-permission'"
+        >
+          <UserPlus class="size-4" :stroke-width="2.6" />
+          Add
+        </button>
+      </div>
+
+      <ul class="mt-4 flex max-h-[320px] flex-col gap-3 overflow-y-auto pr-1">
+        <li v-for="(user, i) in authorizedUsers" :key="i">
+          <ShareQuizAuthorizeUser
+            :user="user"
+            @show-edit-form="showEditForm"
+            @delete-user-permission="deleteUserPermission"
+          />
+        </li>
+        <li
+          v-if="authorizedUsers.length === 0"
+          class="py-4 text-center text-[14px] font-semibold text-jv-muted"
+        >
+          No one has access yet. Add someone to get started.
+        </li>
+      </ul>
+
+      <!-- Add-permission form -->
+      <ShareQuizForm
+        v-if="component === 'give-permission'"
+        form-title="Add People"
+        @share-quiz="shareQuiz"
+      />
+
+      <!-- Edit-permission form -->
+      <ShareQuizForm
+        v-if="component === 'edit-permission'"
+        :id="id"
+        form-title="Edit Permission"
+        :email="email"
+        :permission="permission"
+        @update-user-permission="updateUserPermission"
+      />
+    </template>
+
+    <template #footer>
+      <button
+        type="button"
+        class="inline-flex h-10 items-center justify-center rounded-full border-[2px] border-jv-ink bg-jv-white px-5 font-body text-[14px] font-black text-jv-ink shadow-brutal-sm transition-transform hover:-rotate-[1deg] active:translate-x-[2px] active:translate-y-[2px] active:shadow-none sm:h-11 sm:px-6 sm:text-[15px]"
+        @click="close"
+      >
+        Done
+      </button>
+    </template>
+  </Modal>
+</template>

--- a/app/pages/admin/quiz/list-quiz/[quiz_id]/index.vue
+++ b/app/pages/admin/quiz/list-quiz/[quiz_id]/index.vue
@@ -462,6 +462,8 @@
         </form>
       </div>
     </Teleport>
+
+    <ShareQuizModal v-model="shareModalOpen" :quiz-id="quizId" />
   </main>
 </template>
 
@@ -484,7 +486,7 @@ import { usePush } from "notivue";
 import draggable from "vuedraggable";
 import QuestionFormCard from "@/components/quiz-manage/QuestionFormCard.vue";
 import CodeBlockComponent from "@/components/CodeBlockComponent.vue";
-import usecopyToClipboard from "@/composables/copy_to_clipboard";
+import ShareQuizModal from "@/components/Quiz/ShareQuizModal.vue";
 import { useListUserstore } from "~/store/userlist";
 import { useSessionStore } from "~~/store/session";
 import NavigationLink from "~/components/common/NavigationLink.vue";
@@ -509,6 +511,7 @@ const listUserStore = useListUserstore();
 
 const quizId = computed(() => route.params.quiz_id || "");
 const importModalOpen = ref(false);
+const shareModalOpen = ref(false);
 const importPending = ref(false);
 const csvFile = ref(null);
 const csvFileName = ref("");
@@ -795,8 +798,7 @@ const importCsv = async () => {
 };
 
 const handleShareQuiz = () => {
-  if (!import.meta.client) return;
-  usecopyToClipboard(window.location.href);
+  shareModalOpen.value = true;
 };
 
 const handleStartQuiz = async () => {

--- a/app/pages/admin/quiz/list-quiz/index.vue
+++ b/app/pages/admin/quiz/list-quiz/index.vue
@@ -3,7 +3,7 @@ import { computed, ref, watchEffect } from "vue";
 import { ChevronDown, Filter, Search, X } from "lucide-vue-next";
 import { usePush } from "notivue";
 import AdminQuizListCard from "@/components/quiz-list/AdminQuizListCard.vue";
-import usecopyToClipboard from "@/composables/copy_to_clipboard";
+import ShareQuizModal from "@/components/Quiz/ShareQuizModal.vue";
 import { useListUserstore } from "~/store/userlist";
 import { useSessionStore } from "~~/store/session";
 import { useUsersStore } from "~~/store/users";
@@ -28,6 +28,8 @@ const canCreatePublicQuiz = computed(
 
 const searchQuery = ref("");
 const startingQuizId = ref("");
+const shareModalOpen = ref(false);
+const shareQuizId = ref("");
 const createQuizOpen = ref(false);
 const createQuizPending = ref(false);
 const createQuizForm = ref({
@@ -182,9 +184,8 @@ const handleStartQuiz = async (quizId) => {
 };
 
 const handleShareQuiz = (quiz) => {
-  if (!import.meta.client) return;
-
-  usecopyToClipboard(`${window.location.origin}${quiz.viewUrl}`);
+  shareQuizId.value = quiz.id;
+  shareModalOpen.value = true;
 };
 
 const handleDeleteQuiz = async (quizId) => {
@@ -489,5 +490,7 @@ const handleCreateQuiz = async () => {
         </form>
       </div>
     </Teleport>
+
+    <ShareQuizModal v-model="shareModalOpen" :quiz-id="shareQuizId" />
   </main>
 </template>


### PR DESCRIPTION
**Task:** 
Add Share Quiz Modal for New Web App Theme. 
(https://station.improwised.com/epp/tasks/view/kanban?view=1#IP-103)

**What this PR does:**
Brings back the "Share Quiz" popup that lets you give other people access to a quiz.
It was removed during the theme revamp, so this rebuilds it to match the new design.

What you can do with it:
- See the list of people who already have access to a quiz
- Add a new person by email and pick their permission (read / write / share)
- Edit or remove someone's access

<img width="953" height="896" alt="image" src="https://github.com/user-attachments/assets/a9f41176-10ee-41d9-ae5d-69c1d5677579" />
