### PR TITLE
fix: allow guest users to reach login page after quiz

### DIFF
--- a/app/pages/account/login.vue
+++ b/app/pages/account/login.vue
@@ -201,7 +201,7 @@ const kratosUrl = urls.kratosUrl;
     const user = getUserData();
     const isReauth = !!route.query.returnTo;
 
-    if (!isReauth && user) {
+    if (!isReauth && user && user.role !== "guest-user") {
       navigateTo("/");
       return;
     }


### PR DESCRIPTION
**Task:**
Allow Guest Users to Access Login Page.
(https://station.improwised.com/epp/tasks/view/kanban?view=1#IP-106)

**What this PR does:**
We made the guard role-aware so it only redirects real registered users, not guests.
```
if (!isReauth && user && user.role !== "guest-user") {
  navigateTo("/");
  return;
}
```




