### PR TITLE
feat: validate quiz CSV uploads

### DIFF
--- a/api/constants/constant.go
+++ b/api/constants/constant.go
@@ -119,6 +119,15 @@ const (
 	ErrQuestionId               = "question type id not exists"
 	ErrEmptyFile                = "The uploaded file is empty. Please choose a file with content."
 	ErrUnsupportedFileType      = "The uploaded file is not a valid CSV. Please check the format and try again."
+	ErrEmptyQuestionText        = "question text is required"
+	ErrInsufficientOptions      = "at least 2 options are required"
+	ErrEmptyCorrectAnswer       = "correct answer is required"
+	ErrInvalidCorrectAnswer     = "correct answer must be a number referencing an existing option"
+	ErrInvalidPoints            = "points must be a positive number"
+	ErrInvalidCSVRows           = "the uploaded CSV has invalid rows, please fix them and try again"
+	ErrInvalidQuestionTimeLimit = "question time limit is not configured properly"
+	ErrInvalidQuestionMedia     = "question media must be one of: text, image, code"
+	ErrInvalidOptionsMedia      = "options media must be one of: text, image, code"
 
 	// quiz-id
 	QuizId       = "quiz_id"
@@ -282,6 +291,13 @@ const (
 
 	SingleAnswer = 1
 	Survey       = 2
+)
+
+// Media Types
+const (
+	MediaText  = "text"
+	MediaImage = "image"
+	MediaCode  = "code"
 )
 
 // Pagination and Filters

--- a/api/controllers/api/v1/question_controller.go
+++ b/api/controllers/api/v1/question_controller.go
@@ -198,7 +198,7 @@ func (ctrl *QuestionController) ImportQuestionsByCsv(c *fiber.Ctx) error {
 	validQuestions, err := utils.ExtractQuestionsFromCSV(questions, ctrl.appConfig.Quiz.QuestionTimeLimit)
 	if err != nil {
 		ctrl.logger.Error("file validation failed", zap.Error(err))
-		return utils.JSONFail(c, http.StatusBadRequest, constants.ErrParsingFile)
+		return utils.JSONFail(c, http.StatusBadRequest, err.Error())
 	}
 
 	_, err = ctrl.quizModel.GetQuizById(quizId)

--- a/api/utils/csv_operation.go
+++ b/api/utils/csv_operation.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/Improwised/jovvix/api/constants"
+	quizUtilsHelper "github.com/Improwised/jovvix/api/helpers/utils"
 	"github.com/Improwised/jovvix/api/models"
 	"github.com/google/uuid"
 	"github.com/jszwec/csvutil"
@@ -56,72 +57,146 @@ func ValidateCSVFileFormat(fileName string) ([]Question, error) {
 	return questions, nil
 }
 
+// normalizeMedia trims and lowercases a media value and reports whether it is
+// allowed. An empty value defaults to "text" to match manual question creation.
+func normalizeMedia(media string) (string, bool) {
+	normalized := strings.ToLower(strings.TrimSpace(media))
+	if normalized == "" {
+		return constants.MediaText, true
+	}
+	switch normalized {
+	case constants.MediaText, constants.MediaImage, constants.MediaCode:
+		return normalized, true
+	default:
+		return normalized, false
+	}
+}
+
 func ExtractQuestionsFromCSV(questions []Question, questionTimeLimit string) ([]models.Question, error) {
-	typeMapping := map[string]int{
-		"single answer": 1,
-		"survey":        2,
+	// Duration comes solely from configuration; reject if it is missing or invalid.
+	duration, err := strconv.Atoi(strings.TrimSpace(questionTimeLimit))
+	if err != nil || duration <= 0 {
+		return nil, fmt.Errorf(constants.ErrInvalidQuestionTimeLimit)
 	}
 
 	var validQuestions []models.Question
+	var rowErrors []string
+
 	for i, u := range questions {
+		// Row number as seen by the user in a spreadsheet (header is row 1).
+		rowNo := i + 2
+
+		var rowIssues []string
+
+		// Question text must be present.
+		if strings.TrimSpace(u.Question) == "" {
+			rowIssues = append(rowIssues, constants.ErrEmptyQuestionText)
+		}
+
+		// Question type must be a known type (single answer / survey).
+		questionType, typeErr := quizUtilsHelper.CheckQuestionType(strings.TrimSpace(u.Type))
+		if typeErr != nil {
+			rowIssues = append(rowIssues, fmt.Sprintf("%s (got %q, allowed: %s, %s)", constants.ErrQuestionType, u.Type, constants.SingleAnswerString, constants.SurveyString))
+		}
+
+		// Collect non-empty options, preserving their option number.
+		options := make(map[string]string)
+		for idx, opt := range []string{u.Option1, u.Option2, u.Option3, u.Option4, u.Option5} {
+			if strings.TrimSpace(opt) != "" {
+				options[strconv.Itoa(idx+1)] = opt
+			}
+		}
+		if len(options) < 2 {
+			rowIssues = append(rowIssues, constants.ErrInsufficientOptions)
+		}
+
+		// Correct answer(s): must be present, numeric, and reference an existing option.
+		answers := []int{}
+		correctRaw := strings.TrimSpace(u.CorrectAnswer)
+		if correctRaw == "" {
+			rowIssues = append(rowIssues, constants.ErrEmptyCorrectAnswer)
+		} else {
+			for _, a := range strings.Split(correctRaw, "|") {
+				a = strings.TrimSpace(a)
+				if a == "" {
+					continue
+				}
+				answerInt, convErr := strconv.Atoi(a)
+				if convErr != nil {
+					rowIssues = append(rowIssues, fmt.Sprintf("%s (got %q)", constants.ErrInvalidCorrectAnswer, a))
+					continue
+				}
+				if _, ok := options[strconv.Itoa(answerInt)]; !ok {
+					rowIssues = append(rowIssues, fmt.Sprintf("%s (option %d does not exist)", constants.ErrInvalidCorrectAnswer, answerInt))
+					continue
+				}
+				answers = append(answers, answerInt)
+			}
+		}
+
+		// Type-specific answer count rules (only meaningful when the type is valid).
+		if typeErr == nil {
+			switch questionType {
+			case constants.SingleAnswer:
+				if len(answers) != 1 {
+					rowIssues = append(rowIssues, constants.ErrSingleAnswerLength)
+				}
+			case constants.Survey:
+				if len(answers) < 1 {
+					rowIssues = append(rowIssues, constants.ErrSurveyAnswerLength)
+				}
+			}
+		}
+
+		// Media types: optional (default text), but must be text, image, or code.
+		questionMedia, questionMediaOK := normalizeMedia(u.QuestionMedia)
+		if !questionMediaOK {
+			rowIssues = append(rowIssues, fmt.Sprintf("%s (got %q)", constants.ErrInvalidQuestionMedia, u.QuestionMedia))
+		}
+		optionsMedia, optionsMediaOK := normalizeMedia(u.OptionsMedia)
+		if !optionsMediaOK {
+			rowIssues = append(rowIssues, fmt.Sprintf("%s (got %q)", constants.ErrInvalidOptionsMedia, u.OptionsMedia))
+		}
+
+		// Points: optional, but if present must be a positive integer.
+		points := 1
+		if strings.TrimSpace(u.Points) != "" {
+			parsedPoints, convErr := strconv.Atoi(strings.TrimSpace(u.Points))
+			if convErr != nil || parsedPoints <= 0 {
+				rowIssues = append(rowIssues, fmt.Sprintf("%s (got %q)", constants.ErrInvalidPoints, u.Points))
+			} else {
+				points = parsedPoints
+			}
+		}
+
+		if len(rowIssues) > 0 {
+			rowErrors = append(rowErrors, fmt.Sprintf("row %d: %s", rowNo, strings.Join(rowIssues, "; ")))
+			continue
+		}
 
 		id, err := uuid.NewUUID()
 		if err != nil {
 			return validQuestions, err
 		}
 
-		options := make(map[string]string)
-		if u.Option1 != "" {
-			options["1"] = u.Option1
-		}
-		if u.Option2 != "" {
-			options["2"] = u.Option2
-		}
-		if u.Option3 != "" {
-			options["3"] = u.Option3
-		}
-		if u.Option4 != "" {
-			options["4"] = u.Option4
-		}
-		if u.Option5 != "" {
-			options["5"] = u.Option5
-		}
-
-		answers := []int{}
-		for _, a := range strings.Split(u.CorrectAnswer, "|") {
-			if a != "" {
-				answerInt := 0
-				fmt.Sscanf(a, "%d", &answerInt)
-				answers = append(answers, answerInt)
-			}
-		}
-
-		// Determine points
-		points := 1
-		if u.Points != "" {
-			fmt.Sscanf(u.Points, "%d", &points)
-		}
-
-		duration := 30
-		if questionTimeLimit != "" {
-			if parsedDuration, err := strconv.Atoi(questionTimeLimit); err == nil {
-				duration = parsedDuration
-			}
-		}
-
 		validQuestions = append(validQuestions, models.Question{
 			ID:                id,
 			Question:          u.Question,
-			Type:              typeMapping[u.Type],
+			Type:              questionType,
 			Options:           options,
 			Answers:           answers,
 			Points:            int16(points),
 			DurationInSeconds: duration,
 			OrderNumber:       i + 1,
-			QuestionMedia:     u.QuestionMedia,
-			OptionsMedia:      u.OptionsMedia,
+			QuestionMedia:     questionMedia,
+			OptionsMedia:      optionsMedia,
 			Resource:          sql.NullString{String: u.Resource, Valid: true},
 		})
 	}
+
+	if len(rowErrors) > 0 {
+		return nil, fmt.Errorf("%s %s", constants.ErrInvalidCSVRows, strings.Join(rowErrors, " | "))
+	}
+
 	return validQuestions, nil
 }

--- a/api/utils/csv_operation_test.go
+++ b/api/utils/csv_operation_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/Improwised/jovvix/api/constants"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -123,33 +124,20 @@ func TestExtractQuestionsFromCSV(t *testing.T) {
 		assert.Equal(t, "text", validQuestions[1].OptionsMedia)
 	})
 
-	t.Run("Empty Options", func(t *testing.T) {
-		questions := []Question{
-			{
-				Question:      "Choose the best option",
-				Type:          "single answer",
-				Points:        "10",
-				CorrectAnswer: "1",
-			},
-		}
-
-		validQuestions, err := ExtractQuestionsFromCSV(questions, "")
-		assert.NoError(t, err)
-		assert.Len(t, validQuestions, 1)
-
-		assert.Equal(t, map[string]string{}, validQuestions[0].Options)
-	})
-
 	t.Run("Different Question Types", func(t *testing.T) {
 		questions := []Question{
 			{
 				Question:      "Select the correct statement",
 				Type:          "single answer",
+				Option1:       "True",
+				Option2:       "False",
 				CorrectAnswer: "1",
 			},
 			{
 				Question:      "Provide your feedback",
 				Type:          "survey",
+				Option1:       "Yes",
+				Option2:       "No",
 				CorrectAnswer: "2",
 			},
 		}
@@ -169,7 +157,9 @@ func TestExtractQuestionsFromCSV(t *testing.T) {
 				Question:      "How many continents are there?",
 				Type:          "single answer",
 				Points:        "2",
-				CorrectAnswer: "7",
+				Option1:       "6",
+				Option2:       "7",
+				CorrectAnswer: "2",
 			},
 		}
 
@@ -179,7 +169,94 @@ func TestExtractQuestionsFromCSV(t *testing.T) {
 		assert.Equal(t, 120, validQuestions[0].DurationInSeconds)
 	})
 
-	t.Run("Empty Fields", func(t *testing.T) {
+	t.Run("Invalid question type is rejected", func(t *testing.T) {
+		questions := []Question{
+			{
+				Question:      "What does CPU stand for?",
+				Type:          "MCQ",
+				Option1:       "Central Processing Unit",
+				Option2:       "Computer Processing Unit",
+				CorrectAnswer: "1",
+			},
+		}
+
+		validQuestions, err := ExtractQuestionsFromCSV(questions, "30")
+		assert.Error(t, err)
+		assert.Empty(t, validQuestions)
+		assert.Contains(t, err.Error(), constants.ErrQuestionType)
+	})
+
+	t.Run("Insufficient options is rejected", func(t *testing.T) {
+		questions := []Question{
+			{
+				Question:      "Choose the best option",
+				Type:          "single answer",
+				Points:        "10",
+				Option1:       "Only one",
+				CorrectAnswer: "1",
+			},
+		}
+
+		validQuestions, err := ExtractQuestionsFromCSV(questions, "30")
+		assert.Error(t, err)
+		assert.Empty(t, validQuestions)
+		assert.Contains(t, err.Error(), constants.ErrInsufficientOptions)
+	})
+
+	t.Run("Missing or invalid time limit config is rejected", func(t *testing.T) {
+		questions := []Question{
+			{
+				Question:      "Pick one",
+				Type:          "single answer",
+				Option1:       "A",
+				Option2:       "B",
+				CorrectAnswer: "1",
+			},
+		}
+
+		for _, badLimit := range []string{"", "abc", "0", "-5"} {
+			validQuestions, err := ExtractQuestionsFromCSV(questions, badLimit)
+			assert.Error(t, err)
+			assert.Empty(t, validQuestions)
+			assert.Contains(t, err.Error(), constants.ErrInvalidQuestionTimeLimit)
+		}
+	})
+
+	t.Run("Correct answer referencing missing option is rejected", func(t *testing.T) {
+		questions := []Question{
+			{
+				Question:      "How many continents are there?",
+				Type:          "single answer",
+				Option1:       "6",
+				Option2:       "7",
+				CorrectAnswer: "7",
+			},
+		}
+
+		validQuestions, err := ExtractQuestionsFromCSV(questions, "120")
+		assert.Error(t, err)
+		assert.Empty(t, validQuestions)
+		assert.Contains(t, err.Error(), constants.ErrInvalidCorrectAnswer)
+	})
+
+	t.Run("Single answer with multiple correct answers is rejected", func(t *testing.T) {
+		questions := []Question{
+			{
+				Question:      "Pick one",
+				Type:          "single answer",
+				Option1:       "A",
+				Option2:       "B",
+				CorrectAnswer: "1|2",
+			},
+		}
+
+		validQuestions, err := ExtractQuestionsFromCSV(questions, "30")
+		assert.Error(t, err)
+		assert.Empty(t, validQuestions)
+		assert.Contains(t, err.Error(), constants.ErrSingleAnswerLength)
+	})
+
+	t.Run("Empty fields are rejected", func(t *testing.T) {
 		questions := []Question{
 			{
 				Question:      "",
@@ -189,10 +266,80 @@ func TestExtractQuestionsFromCSV(t *testing.T) {
 		}
 
 		validQuestions, err := ExtractQuestionsFromCSV(questions, "20")
+		assert.Error(t, err)
+		assert.Empty(t, validQuestions)
+		assert.Contains(t, err.Error(), constants.ErrEmptyQuestionText)
+	})
+
+	t.Run("Invalid media type is rejected", func(t *testing.T) {
+		questions := []Question{
+			{
+				Question:      "Pick one",
+				Type:          "single answer",
+				Option1:       "A",
+				Option2:       "B",
+				CorrectAnswer: "1",
+				QuestionMedia: "video",
+				OptionsMedia:  "text",
+			},
+		}
+
+		validQuestions, err := ExtractQuestionsFromCSV(questions, "30")
+		assert.Error(t, err)
+		assert.Empty(t, validQuestions)
+		assert.Contains(t, err.Error(), constants.ErrInvalidQuestionMedia)
+	})
+
+	t.Run("Media is normalized and empty defaults to text", func(t *testing.T) {
+		questions := []Question{
+			{
+				Question:      "Pick one",
+				Type:          "single answer",
+				Option1:       "A",
+				Option2:       "B",
+				CorrectAnswer: "1",
+				QuestionMedia: "  Image ",
+				OptionsMedia:  "",
+			},
+		}
+
+		validQuestions, err := ExtractQuestionsFromCSV(questions, "30")
 		assert.NoError(t, err)
 		assert.Len(t, validQuestions, 1)
+		assert.Equal(t, constants.MediaImage, validQuestions[0].QuestionMedia)
+		assert.Equal(t, constants.MediaText, validQuestions[0].OptionsMedia)
+	})
 
-		assert.Equal(t, "", validQuestions[0].Question)
-		assert.Equal(t, []int{}, validQuestions[0].Answers)
+	t.Run("Multiple bad rows are all reported", func(t *testing.T) {
+		questions := []Question{
+			{
+				Question:      "Good one",
+				Type:          "single answer",
+				Option1:       "A",
+				Option2:       "B",
+				CorrectAnswer: "1",
+			},
+			{
+				Question:      "Bad type",
+				Type:          "MCQ",
+				Option1:       "A",
+				Option2:       "B",
+				CorrectAnswer: "1",
+			},
+			{
+				Question:      "Bad answer",
+				Type:          "single answer",
+				Option1:       "A",
+				Option2:       "B",
+				CorrectAnswer: "9",
+			},
+		}
+
+		validQuestions, err := ExtractQuestionsFromCSV(questions, "30")
+		assert.Error(t, err)
+		assert.Empty(t, validQuestions)
+		// Row numbers are 1-based with the header as row 1.
+		assert.Contains(t, err.Error(), "row 3")
+		assert.Contains(t, err.Error(), "row 4")
 	})
 }


### PR DESCRIPTION
**Problem:**
Uploading a CSV with invalid data (e.g. an unrecognized question type) was silently accepted, showed a "Questions imported successfully" toast, and stored garbage. The bad data then crashed the quiz view with [GET] /api/v1/quizzes/{id}/questions: 500 Internal Server Error, because an invalid question type was silently coerced to 0, which no downstream lookup could resolve.

**validation added:**
- **Question Type :**	Must be single answer or survey (now uses the shared CheckQuestionType helper instead of a silent map lookup). This is the fix for the 500.
- **Question Text :**	Required (non-empty after trim).
- **Options :**	At least 2 non-empty options required.
- **Correct Answer :**	Required; each value must be numeric (now strconv.Atoi, no silent Sscanf); each must reference an option that actually exists (catches "answer = 7 but only 4 options").
- **Correct Answer count :**	single answer → exactly one correct answer; survey → at least one.
- **Points :**	Optional; if present must be a positive integer (rejects abc, 0, -5). Defaults to 1 when blank.
- **Question Media / Options Media :**	Must be text, image, or code. Empty defaults to text (matching manual question creation). Values are trimmed + lowercased, so Image/CODE are accepted and stored normalized so the frontend renders them correctly.