### PR TITLE
fix: correct invisible overview heading color in quiz report

### DIFF
--- a/app/pages/admin/reports/[id]/index.vue
+++ b/app/pages/admin/reports/[id]/index.vue
@@ -39,7 +39,7 @@
             Class Performance Overview
           </div>
           <h2
-            class="mt-3 font-headings text-[28px] leading-tight sm:text-[32px] md:text-[36px]"
+            class="mt-3 font-headings text-[28px] leading-tight text-white sm:text-[32px] md:text-[36px]"
           >
             {{ overallMessage }}
           </h2>


### PR DESCRIPTION
**Task:** Performance text is not clearly visible on the Report screen
https://station.improwised.com/epp/tasks/view/kanban?view=1#IP-143