### PR TITLE
fix: single back click leaves login page

### DIFF
--- a/app/pages/account/login.vue
+++ b/app/pages/account/login.vue
@@ -241,10 +241,6 @@ const kratosUrl = urls.kratosUrl;
             id: route.query.flow,
           },
           onResponseError({ response }) {
-            if (response._data?.error?.code === 410) {
-              navigateTo("/account/login");
-            }
-
             if (response.status === 400) {
               toast.warning(
                 "Please fill out the form correctly, password or email was incorrect"
@@ -313,7 +309,7 @@ async function setFlowIDAndCSRFToken() {
         )}`
       : `?flow=${kratosResponse?.id}`;
 
-    router.push(queryParams);
+    router.replace(queryParams);
     csrfToken.value = kratosResponse?.ui?.nodes.find(
       (node) => node.attributes.name === "csrf_token"
     )?.attributes?.value;

--- a/app/pages/account/register.vue
+++ b/app/pages/account/register.vue
@@ -91,10 +91,6 @@ function onSubmit(event) {
             id: route.query.flow,
           },
           onResponseError({ response }) {
-            if (response._data?.error?.code === 410) {
-              navigateTo("/account/register");
-            }
-
             if (response.status === 400) {
               toast.warning(
                 "Please fill out the form correctly, password or email was incorrect"
@@ -181,7 +177,7 @@ async function setFlowIDAndCSRFToken() {
       }
     );
 
-    router.push(
+    router.replace(
       returnTo.value
         ? `?flow=${kratosResponse?.id}&returnTo=${encodeURIComponent(
             returnTo.value


### PR DESCRIPTION
**Task:** Back button requires two clicks to return to Home from Login page
https://station.improwised.com/epp/tasks/view/kanban?view=1#IP-187

**Changes**

- `app/pages/account/login.vue` — switched the flow-id rewrite from `router.push` to `router.replace`, so it updates the current history entry instead of stacking a new one.
- `app/pages/account/register.vue` — same fix; the register page had the identical bug.
- Removed the redundant `navigateTo` calls from the `410` (expired flow) handlers in both pages. They pushed yet another history entry and did nothing useful, since `setFlowIDAndCSRFToken()` runs immediately afterwards and now replaces the URL with a fresh flow id.

**Impact**

- No behaviour change to the login/register flows themselves — the flow id and `returnTo` still appear in the URL exactly as before.
