### PR TITLE
fix: allow deleting a quiz that has already been played

### DIFF
--- a/api/models/quiz.go
+++ b/api/models/quiz.go
@@ -593,8 +593,37 @@ func (model *QuizModel) ListQuizzesAnalysis(name, order, orderBy, date, userId s
 
 // Delete quiz and and their question using `quiz_id`
 func (model *QuizModel) DeleteQuizById(transaction *goqu.TxDatabase, QuizId string) error {
+	activeQuizSubquery := transaction.From(ActiveQuizzesTable).Select("id").Where(goqu.Ex{"quiz_id": QuizId})
+
+	userPlayedQuizSubquery := transaction.From(UserPlayedQuizTable).Select("id").Where(goqu.Ex{"active_quiz_id": goqu.Op{"in": activeQuizSubquery}})
+
+	_, err := transaction.Delete(UserQuizResponsesTable).Where(goqu.Ex{"user_played_quiz_id": goqu.Op{"in": userPlayedQuizSubquery}}).Executor().Exec()
+	if err != nil {
+		return err
+	}
+
+	_, err = transaction.Delete(UserPlayedQuizTable).Where(goqu.Ex{"active_quiz_id": goqu.Op{"in": activeQuizSubquery}}).Executor().Exec()
+	if err != nil {
+		return err
+	}
+
+	_, err = transaction.Delete(ActiveQuizQuestionsTable).Where(goqu.Ex{"active_quiz_id": goqu.Op{"in": activeQuizSubquery}}).Executor().Exec()
+	if err != nil {
+		return err
+	}
+
+	_, err = transaction.Delete(ActiveQuizzesTable).Where(goqu.Ex{"quiz_id": QuizId}).Executor().Exec()
+	if err != nil {
+		return err
+	}
+
+	_, err = transaction.Delete(SharedQuizzesTable).Where(goqu.Ex{"quiz_id": QuizId}).Executor().Exec()
+	if err != nil {
+		return err
+	}
+
 	questionIds := []string{}
-	err := transaction.Delete(constants.QuizQuestionsTable).Where(goqu.Ex{"quiz_id": QuizId}).Returning("question_id").Executor().ScanVals(&questionIds)
+	err = transaction.Delete(constants.QuizQuestionsTable).Where(goqu.Ex{"quiz_id": QuizId}).Returning("question_id").Executor().ScanVals(&questionIds)
 	if err != nil {
 		return err
 	}

--- a/app/pages/admin/quiz/list-quiz/[quiz_id]/index.vue
+++ b/app/pages/admin/quiz/list-quiz/[quiz_id]/index.vue
@@ -82,7 +82,7 @@
           <NavigationLink
             url-name="Delete Quiz"
             class="bg-jv-white text-jv-coral border-none shadow-none"
-            @click="deleteQuiz"
+            @click="deleteModalOpen = true"
           >
             <Trash2 class="size-4" :stroke-width="2.4" />
           </NavigationLink>
@@ -546,6 +546,13 @@
     </Teleport>
 
     <ShareQuizModal v-model="shareModalOpen" :quiz-id="quizId" />
+    <DeleteDialog
+      v-model="deleteModalOpen"
+      title="Delete quiz"
+      :message="deleteQuizMessage"
+      confirm-label="Delete quiz"
+      @confirm-delete="deleteQuiz"
+    />
   </main>
 </template>
 
@@ -602,6 +609,7 @@ const listUserStore = useListUserstore();
 const quizId = computed(() => route.params.quiz_id || "");
 const importModalOpen = ref(false);
 const shareModalOpen = ref(false);
+const deleteModalOpen = ref(false);
 const importPending = ref(false);
 const csvFile = ref(null);
 const csvFileName = ref("");
@@ -654,6 +662,11 @@ onMounted(() => {
 
 const questions = computed(() => quizData.value?.data?.data || []);
 const quizTitle = computed(() => quizData.value?.data?.quiz_title || "Quiz");
+
+const deleteQuizMessage = computed(
+  () =>
+    `Deleting "${quizTitle.value}" also removes its questions, every session hosted from it, and all player scores and responses. This cannot be undone.`
+);
 const quizDescription = computed(
   () => quizData.value?.data?.quiz_description?.String || ""
 );
@@ -875,8 +888,6 @@ const deleteQuestion = async (questionId) => {
 };
 
 const deleteQuiz = async () => {
-  if (!window.confirm("Delete this quiz?")) return;
-
   try {
     await $fetch(`${url.apiUrl}/quizzes/${quizId.value}`, {
       method: "DELETE",

--- a/app/pages/admin/quiz/list-quiz/index.vue
+++ b/app/pages/admin/quiz/list-quiz/index.vue
@@ -43,6 +43,8 @@ const searchQuery = ref("");
 const startingQuizId = ref("");
 const shareModalOpen = ref(false);
 const shareQuizId = ref("");
+const deleteModalOpen = ref(false);
+const quizPendingDelete = ref(null);
 const createQuizOpen = ref(false);
 const createQuizPending = ref(false);
 const coverImageName = ref("");
@@ -230,7 +232,22 @@ const handleShareQuiz = (quiz) => {
   shareModalOpen.value = true;
 };
 
-const handleDeleteQuiz = async (quizId) => {
+const deleteQuizMessage = computed(() => {
+  const title = quizPendingDelete.value?.title;
+  return `Deleting ${
+    title ? `"${title}"` : "this quiz"
+  } also removes its questions, every session hosted from it, and all player scores and responses. This cannot be undone.`;
+});
+
+const handleDeleteQuiz = (quiz) => {
+  quizPendingDelete.value = quiz;
+  deleteModalOpen.value = true;
+};
+
+const confirmDeleteQuiz = async () => {
+  const quizId = quizPendingDelete.value?.id;
+  if (!quizId) return;
+
   try {
     await $fetch(`${url.apiUrl}/quizzes/${quizId}`, {
       method: "DELETE",
@@ -244,6 +261,8 @@ const handleDeleteQuiz = async (quizId) => {
     toast.error(
       error?.data?.message || error?.message || "Failed to delete quiz."
     );
+  } finally {
+    quizPendingDelete.value = null;
   }
 };
 
@@ -446,7 +465,7 @@ const handleCreateQuiz = async () => {
         :starting="startingQuizId === quiz.id"
         @start-quiz="handleStartQuiz(quiz.id)"
         @share="handleShareQuiz(quiz)"
-        @delete="handleDeleteQuiz(quiz.id)"
+        @delete="handleDeleteQuiz(quiz)"
       />
     </section>
 
@@ -619,5 +638,12 @@ const handleCreateQuiz = async () => {
     </Teleport>
 
     <ShareQuizModal v-model="shareModalOpen" :quiz-id="shareQuizId" />
+    <DeleteDialog
+      v-model="deleteModalOpen"
+      title="Delete quiz"
+      :message="deleteQuizMessage"
+      confirm-label="Delete quiz"
+      @confirm-delete="confirmDeleteQuiz"
+    />
   </main>
 </template>


### PR DESCRIPTION
**Task:** Check Quiz Deletion for Played Public and Private Quizzes
https://station.improwised.com/epp/tasks/view/kanban?view=1#IP-186

- Deleting a quiz failed with a Postgres foreign-key error if it had ever been
  played or shared — the raw error was shown in a toast.
- Cause: hosting a quiz reuses the same `questions` rows, and the delete only
  cleaned up `quiz_questions`, `questions` and `quizzes`. Five tables still
  referenced those rows, and no FK in the schema has `ON DELETE CASCADE`.
- Fixed `DeleteQuizById` to clear everything the quiz owns, leaf-first:
  user responses → played quizzes → session questions → sessions → shares,
  then the questions and the quiz. All inside the existing transaction.
- Same cascade pattern already used by account deletion; it had just never been
  applied to single-quiz delete.
- Added a confirmation dialog to both delete entry points. The quiz-list kebab
  menu previously deleted on one click with no prompt; the detail page used a
  plain browser `confirm`. Both now use the existing `DeleteDialog` component.
- The dialog names the quiz and warns that its sessions and all player scores go
  with it, since the delete is permanent.
- Unchanged: a quiz with a live session still can't be deleted.

