### PR TITLE
fix: show 0 instead of -0.00 for avg completion time

### DIFF
--- a/app/pages/admin/reports/[id]/index.vue
+++ b/app/pages/admin/reports/[id]/index.vue
@@ -416,7 +416,7 @@ const avgCompletion = computed(() => {
   if (!data?.length) return 0;
   const mean =
     data.reduce((sum, q) => sum + (q.avg_response_time || 0), 0) / data.length;
-  return mean / 1000;
+  return Math.max(0, mean / 1000);
 });
 
 const overallMessage = computed(() => {


### PR DESCRIPTION
Task: Average completion time displays "- 0 sec" when all questions are skipped.
https://station.improwised.com/epp/cycles/jovVix%20Fixes%20&%20Enhancements/tasks/view#IP-144