### PR TITLE
fix: label share permission as manage in quiz sharing ui

### DIFF
--- a/app/components/Quiz/ShareQuizAuthorizeUser.vue
+++ b/app/components/Quiz/ShareQuizAuthorizeUser.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { computed } from "vue";
 import { Pencil, Trash2 } from "lucide-vue-next";
 
 const props = defineProps({
@@ -16,6 +17,11 @@ const props = defineProps({
 });
 
 const emits = defineEmits(["showEditForm", "deleteUserPermission"]);
+
+const permissionLabels = { read: "Read", write: "Write", share: "Manage" };
+const permissionLabel = computed(
+  () => permissionLabels[props.user.permission] ?? props.user.permission
+);
 
 // open the edit form to change this user's permission for the quiz
 const showEditForm = () => {
@@ -68,7 +74,7 @@ const showEditForm = () => {
       <span
         class="rounded-full border-[2px] border-jv-ink bg-jv-yellow px-2.5 py-1 text-[12px] font-black uppercase tracking-[0.08em] text-jv-ink"
       >
-        {{ props.user.permission }}
+        {{ permissionLabel }}
       </span>
       <span
         v-if="props.isSelf"

--- a/app/components/Quiz/ShareQuizForm.vue
+++ b/app/components/Quiz/ShareQuizForm.vue
@@ -101,7 +101,7 @@ const handleSubmit = () => {
         <option value="" disabled>Select permission level</option>
         <option value="read">Read</option>
         <option value="write">Write</option>
-        <option value="share">Share</option>
+        <option value="share">Manage</option>
       </select>
     </label>
 

--- a/app/components/Quiz/ShareQuizModal.vue
+++ b/app/components/Quiz/ShareQuizModal.vue
@@ -66,7 +66,7 @@ const isPermissionDenied = computed(() => {
 const accessErrorMessage = computed(() => {
   if (!quizAuthorizedUsersError.value) return "";
   if (isPermissionDenied.value) {
-    return 'You don\'t have permission to share this quiz. Ask the quiz owner for "share" access to invite others.';
+    return 'You don\'t have permission to share this quiz. Ask the quiz owner for "manage" access to invite others.';
   }
   return "Couldn't load who has access to this quiz. Please try again.";
 });


### PR DESCRIPTION
Task: Rename "Share" Permission to "Manage"
https://station.improwised.com/epp/tasks/view/kanban?view=1#IP-209