### PR TITLE
fix: label paused quiz button as resume

### DIFF
--- a/app/pages/admin/arrange/[session_id].vue
+++ b/app/pages/admin/arrange/[session_id].vue
@@ -483,7 +483,7 @@ useSeoMeta({
           class="inline-flex h-11 w-full items-center justify-center rounded-[8px] border-[3px] border-jv-ink bg-jv-mint px-5 text-[15px] font-black text-jv-ink shadow-brutal-sm transition-transform hover:rotate-[1deg] active:translate-x-[2px] active:translate-y-[2px] active:shadow-none sm:w-fit sm:text-[16px]"
           @click="handlePauseQuiz"
         >
-          START
+          RESUME
         </button>
         <button
           v-else


### PR DESCRIPTION
Task: Incorrect button label displayed when a quiz is paused
https://station.improwised.com/epp/tasks/view/kanban?view=1&project=[%22in%22,%22IP,+AK%22]&subject=[%22LIKE%22,%22%25incorre%25%22]#IP-146