### PR TITLE
fix: stop winning music on home navigation

### DIFF
--- a/app/components/FinalScoreBoard.vue
+++ b/app/components/FinalScoreBoard.vue
@@ -175,6 +175,14 @@ onMounted(() => {
   }
 });
 
+onBeforeUnmount(() => {
+  if (!winningSound.value) return;
+
+  winningSound.value.pause();
+  winningSound.value.currentTime = 0;
+  winningSound.value = null;
+});
+
 const winners = computed(() => scoreboardData.value.slice(0, 3));
 
 const userRow = computed(() =>


### PR DESCRIPTION
Task: Winning Screen Music Doesn't Stop When Navigating Home
https://station.improwised.com/epp/tasks/view/kanban?view=1#IP-259