### PR TITLE
fix: prevent quiz hosts from playing

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Open-Source Quizzing Built for Live Quiz Experiences
 - **Public Quizzes:** Curated quizzes can be published publicly and explored right from the homepage — no account required:
   - Anyone, including guests who haven't logged in, can start a public quiz instantly
   - The quiz session can be shared with others so they can join and participate together
-  - The host of a public quiz can also play along as a participant
+  - The host runs the session while participants play
 - **Multiple Question Types:** Allows admins to create quizzes with different question formats:
   - Multiple-choice questions
   - Survey-based questions

--- a/api/controllers/api/v1/quiz_controller.go
+++ b/api/controllers/api/v1/quiz_controller.go
@@ -475,8 +475,8 @@ func (ctrl *QuizController) GenerateDemoSession(c *fiber.Ctx) error {
 
 // GeneratePublicSession lets ANY visitor (guest or registered) host a public quiz.
 // Unlike demo_session, it does not require Kratos auth, but it only works for
-// quizzes flagged is_public. The starter becomes the session host; whether they
-// may also play is decided later at PlayedQuizValidation (creators stay host-only).
+// quizzes flagged is_public. The starter becomes the session host and cannot
+// participate in that session.
 func (ctrl *QuizController) GeneratePublicSession(c *fiber.Ctx) error {
 	quizId := c.Params(constants.QuizId)
 	userId := quizUtilsHelper.GetString(c.Locals(constants.ContextUid))

--- a/api/controllers/api/v1/quiz_socket_controller.go
+++ b/api/controllers/api/v1/quiz_socket_controller.go
@@ -680,10 +680,8 @@ func handleCodeGeneration(c *websocket.Conn, qc *quizSocketController, session m
 						qc.logger.Error("error while unmarshaling redis inside updateUserData", zap.Error(err))
 					}
 
-					// A public-quiz host can also be a player. Such a host is recorded in
-					// user_played_quizzes but never in the redis join list (that is only
-					// populated by the join socket), so fall back to the DB participant
-					// count to allow starting with the host playing solo.
+					// A host is never a participant. Use the persisted participant count as
+					// a fallback for real players whose join-list update has not arrived yet.
 					participantCount, countErr := qc.userPlayedQuizModel.GetCountOfTotalJoinUsers(session.ID.String())
 					if countErr != nil {
 						qc.logger.Error(constants.ErrGetTotalJoinUser, zap.Error(countErr))
@@ -1343,6 +1341,15 @@ func (qc *quizSocketController) SetAnswer(c *fiber.Ctx) error {
 	if !ok {
 		qc.logger.Error("Unable to convert to user-model type from locals")
 		return utils.JSONFail(c, http.StatusInternalServerError, "Unable to convert to user-model type from locals")
+	}
+
+	isParticipant, err := qc.userPlayedQuizModel.IsParticipant(user.ID, currentQuizId, sessionId)
+	if err != nil {
+		qc.logger.Error("error validating answer participant", zap.Error(err))
+		return utils.JSONFail(c, http.StatusInternalServerError, constants.UnknownError)
+	}
+	if !isParticipant {
+		return utils.JSONFail(c, http.StatusForbidden, "only session participants can submit answers")
 	}
 
 	var answer structs.ReqAnswerSubmit

--- a/api/controllers/api/v1/user_played_score_quiz.go
+++ b/api/controllers/api/v1/user_played_score_quiz.go
@@ -143,20 +143,11 @@ func (ctrl *UserPlayedQuizeController) PlayedQuizValidation(c *fiber.Ctx) error 
 	}
 	ctrl.logger.Debug("activeQuizModel.activeQuizModel success", zap.Any("session", session))
 
-	// The host normally cannot play their own session. Exception: for a PUBLIC quiz,
-	// whoever started it may also play — guest, registered user, or the quiz creator
-	// alike. Hosts of non-public (demo/private) sessions stay host-only.
+	// The user who started a session is always its host, never a participant.
+	// This is independent of quiz visibility and ownership.
 	if userId == session.AdminID {
-		quiz, err := ctrl.quizModel.GetQuizById(session.QuizID.String())
-		if err != nil {
-			ctrl.logger.Error("error fetching quiz during PlayedQuizValidation", zap.Error(err))
-			return utils.JSONFail(c, http.StatusInternalServerError, constants.ErrUserQuizSessionValidation)
-		}
-
-		if !quiz.IsPublic {
-			ctrl.logger.Error(constants.ErrAdminCannotBeUser)
-			return utils.JSONFail(c, http.StatusForbidden, constants.ErrAdminCannotBeUser)
-		}
+		ctrl.logger.Error(constants.ErrAdminCannotBeUser)
+		return utils.JSONFail(c, http.StatusForbidden, constants.ErrAdminCannotBeUser)
 	}
 
 	ctrl.logger.Debug("userPlayedQuizModel.CreateUserPlayedQuizIfNotExists called", zap.Any("userId", userId), zap.Any("sessionID", session.ID))

--- a/api/models/final_scoreboard.go
+++ b/api/models/final_scoreboard.go
@@ -60,6 +60,7 @@ func (model *FinalScoreBoardModel) GetScore(user_played_quiz string) ([]FinalSco
 			goqu.Ex{
 				UserQuizResponseTable + ".user_played_quiz_id": goqu.I(UserPlayedQuizTable + ".id"),
 				UserPlayedQuizTable + ".active_quiz_id":        activeQuizId,
+				UserPlayedQuizTable + ".is_host":               false,
 			},
 		).
 		GroupBy(goqu.I("users.id")).

--- a/api/models/final_scoreboard_admin.go
+++ b/api/models/final_scoreboard_admin.go
@@ -51,6 +51,7 @@ func (model *FinalScoreBoardAdminModel) GetScoreForAdmin(activeQuizId string) ([
 		Where(goqu.Ex{
 			UserQuizResponseTable + ".user_played_quiz_id": goqu.I(UserPlayedQuizTable + ".id"),
 			UserPlayedQuizTable + ".active_quiz_id":        activeQuizId,
+			UserPlayedQuizTable + ".is_host":               false,
 		}).
 		GroupBy(goqu.I("users.id")).
 		ScanStructs(&finalScoreBoardData)

--- a/api/models/quiz.go
+++ b/api/models/quiz.go
@@ -50,13 +50,13 @@ type QuizzesAnalysis struct {
 }
 
 type QuizWithQuestions struct {
-	ID           uuid.UUID      `json:"id" db:"id"`
-	Title        string         `json:"title" db:"title" validate:"required"`
-	Description  sql.NullString `json:"description,omitempty" db:"description"`
-	CreatorID    *string        `json:"creator_id,omitempty" db:"creator_id"`
-	IsPublic     bool           `json:"is_public" db:"is_public"`
-	CategoryId   sql.NullString `json:"category_id,omitempty" db:"category_id"`
-	CategoryName sql.NullString `json:"category_name,omitempty" db:"category_name"`
+	ID             uuid.UUID      `json:"id" db:"id"`
+	Title          string         `json:"title" db:"title" validate:"required"`
+	Description    sql.NullString `json:"description,omitempty" db:"description"`
+	CreatorID      *string        `json:"creator_id,omitempty" db:"creator_id"`
+	IsPublic       bool           `json:"is_public" db:"is_public"`
+	CategoryId     sql.NullString `json:"category_id,omitempty" db:"category_id"`
+	CategoryName   sql.NullString `json:"category_name,omitempty" db:"category_name"`
 	CoverImage     sql.NullString `json:"-" db:"cover_image"`
 	HasCoverImage  bool           `json:"has_cover_image" db:"has_cover_image"`
 	CreatedAt      time.Time      `json:"created_at,omitempty" db:"created_at,omitempty"`
@@ -462,11 +462,13 @@ func (model *QuizModel) IsAllAnswerGathered(sessionId uuid.UUID, questionId uuid
 					"user_played_quiz_id": goqu.I("upq.id"),
 					"active_quiz_id":      sessionId,
 					"question_id":         questionId,
-				})).Select(
-		goqu.COUNT("upr.id").Eq(goqu.SUM(goqu.Case().
-			When(goqu.I("upr.is_attend").Eq(true), 1).
-			Else(0))).
-			As("is_skippable")).ScanVal(&skippable)
+				})).
+		Where(goqu.I("upq.is_host").Eq(false)).
+		Select(
+			goqu.COUNT("upr.id").Eq(goqu.SUM(goqu.Case().
+				When(goqu.I("upr.is_attend").Eq(true), 1).
+				Else(0))).
+				As("is_skippable")).ScanVal(&skippable)
 
 	if err != nil {
 		return false, err
@@ -491,7 +493,7 @@ func (model *QuizModel) GetQuizAnalysis(activeQuizId string) ([]QuizAnalysis, er
 			goqu.L("jsonb_object_agg(?, ?)", goqu.I("u.username"), goqu.I("uqr.answers")).As("selected_answers"),
 			goqu.L("avg(?)", goqu.I("response_time")).As("avg_response_time"),
 		).
-		Where(goqu.Ex{"upq.active_quiz_id": activeQuizId}).
+		Where(goqu.Ex{"upq.active_quiz_id": activeQuizId, "upq.is_host": false}).
 		GroupBy(goqu.C("question_id").Table("uqr"))
 
 	// Define the final query
@@ -568,7 +570,7 @@ func (model *QuizModel) ListQuizzesAnalysis(name, order, orderBy, date, userId s
 		InnerJoin(goqu.T(ActiveQuizQuestionsTable).As("qq"), goqu.On(goqu.Ex{"aq.id": goqu.I("qq.active_quiz_id")})).
 		InnerJoin(goqu.T(UserPlayedQuizTable).As("upq"), goqu.On(goqu.Ex{"upq.active_quiz_id": goqu.I("aq.id")})).
 		InnerJoin(goqu.T(UserQuizResponsesTable).As("uqr"), goqu.On(goqu.Ex{"uqr.question_id": goqu.I("qq.question_id"), "uqr.user_played_quiz_id": goqu.I("upq.id")})).
-		Where(goqu.Ex{"aq.admin_id": userId, "aq.activated_to": goqu.Op{"isNot": nil}}).
+		Where(goqu.Ex{"aq.admin_id": userId, "aq.activated_to": goqu.Op{"isNot": nil}, "upq.is_host": false}).
 		GroupBy(
 			"aq.id",
 			"aq.activated_from",

--- a/api/models/user_played_quizzes.go
+++ b/api/models/user_played_quizzes.go
@@ -187,6 +187,22 @@ func (model *UserPlayedQuizModel) GetCurrentActiveQuestion(id string) (uuid.UUID
 	return currentQuestion, nil
 }
 
+// IsParticipant verifies that a played-quiz record belongs to the requesting user,
+// belongs to the requested session, and is not a host record.
+func (model *UserPlayedQuizModel) IsParticipant(userID string, userPlayedQuizID uuid.UUID, activeQuizID string) (bool, error) {
+	count, err := model.db.From(UserPlayedQuizTable).Where(goqu.Ex{
+		"id":             userPlayedQuizID,
+		"user_id":        userID,
+		"active_quiz_id": activeQuizID,
+		"is_host":        false,
+	}).Count()
+	if err != nil {
+		return false, err
+	}
+
+	return count == 1, nil
+}
+
 type UserRank struct {
 	Rank         int    `json:"rank" db:"rank"`
 	Points       int    `json:"points" db:"points"`
@@ -214,7 +230,7 @@ func (model *UserPlayedQuizModel) GetRank(sessionId uuid.UUID, questionId uuid.U
 				"upq.id":             goqu.I("uqr.user_played_quiz_id"),
 				"upq.active_quiz_id": sessionId,
 			}),
-			))
+			).Where(goqu.I("upq.is_host").Eq(false)))
 
 	getSum := core.
 		With("get_sum", goqu.
@@ -279,6 +295,7 @@ func (model *UserPlayedQuizModel) ListUserPlayedQuizes(userId string, page int, 
 		InnerJoin(goqu.T(constants.QuizQuestionsTable), goqu.On(goqu.I(constants.QuizzesTable+".id").Eq(goqu.I(constants.QuizQuestionsTable+".quiz_id")))).
 		Where(goqu.Ex{
 			UserPlayedQuizTable + ".user_id": userId,
+			UserPlayedQuizTable + ".is_host": false,
 		}).GroupBy("user_played_quizzes.id", "quizzes.id").Order(goqu.I("user_played_quizzes.created_at").Desc())
 
 	if titleSearch != "" {
@@ -368,7 +385,7 @@ func (model *UserPlayedQuizModel) GetJoinedUsers(activeQuizId string) ([]JoinedU
 	err := model.db.Select("u.id", "u.first_name", "u.img_key").
 		From(goqu.T(UserPlayedQuizTable).As("upq")).
 		Join(goqu.T(UserTable).As("u"), goqu.On(goqu.I("u.id").Eq(goqu.I("upq.user_id")))).
-		Where(goqu.I("upq.active_quiz_id").Eq(activeQuizId)).
+		Where(goqu.Ex{"upq.active_quiz_id": activeQuizId, "upq.is_host": false}).
 		Order(goqu.I("upq.created_at").Asc()).
 		ScanStructs(&users)
 
@@ -382,6 +399,7 @@ func (model *UserPlayedQuizModel) GetJoinedUsers(activeQuizId string) ([]JoinedU
 func (model *UserPlayedQuizModel) GetCountOfTotalJoinUsers(activeQuizId string) (int64, error) {
 	return model.db.From(UserPlayedQuizTable).Where(goqu.Ex{
 		"active_quiz_id": activeQuizId,
+		"is_host":        false,
 	}).Count()
 }
 

--- a/app/components/Quiz/QuestionSpace.vue
+++ b/app/components/Quiz/QuestionSpace.vue
@@ -43,12 +43,6 @@ const props = defineProps({
     type: Boolean,
     required: false,
   },
-  // When true, an admin (public-quiz host) is also allowed to answer questions.
-  canPlay: {
-    default: false,
-    type: Boolean,
-    required: false,
-  },
   quizTitle: {
     default: "",
     type: String,
@@ -57,9 +51,7 @@ const props = defineProps({
 });
 const emits = defineEmits(["sendAnswer", "askSkip"]);
 
-// A participant can answer when they are not the admin, or when they are a
-// public-quiz host who is permitted to play alongside the others.
-const answerable = computed(() => !props.isAdmin || props.canPlay);
+const answerable = computed(() => !props.isAdmin);
 
 const clockOffset = ref(0); // Calculated once, used for all timers
 const isOffsetCalculated = ref(false);

--- a/app/components/landing/PublicQuizSection.vue
+++ b/app/components/landing/PublicQuizSection.vue
@@ -189,7 +189,7 @@ const handleStartQuiz = async (quizId) => {
     listUserStore.removeAllUsers();
     setSocketObject(null);
     sessionStore.setSession(sessionId);
-    // `public=1` tells the lobby this is a public session where the host may also play.
+    // `public=1` preserves the public-session flow for a guest host.
     await router.push(`/admin/arrange/${sessionId}?public=1`);
   } catch (error) {
     toast.error(

--- a/app/composables/admin_operation.js
+++ b/app/composables/admin_operation.js
@@ -59,35 +59,6 @@ export default class AdminOperations extends QuizHandler {
     this.sendMessage(this.currentComponent, constants.StartQuiz);
   }
 
-  // For public quizzes the host can also play, so they submit answers through the
-  // same HTTP endpoint a regular player uses. Mirrors UserOperation.handleSendAnswer.
-  async handleSendAnswer(answers, user_played_quiz, session_id) {
-    const responseTime = this.getAnswerResponseTime();
-    try {
-      const response = await fetch(
-        `${this.apiUrl}/quiz/answer?user_played_quiz=${user_played_quiz}&session_id=${session_id}`,
-        {
-          method: "POST",
-          body: JSON.stringify({
-            id: this.currentQuestion,
-            keys: answers || [],
-            response_time: responseTime,
-          }),
-          credentials: "include",
-          mode: "cors",
-        }
-      );
-
-      if (response.status !== 202) {
-        return { error: `Failed to submit answer` };
-      }
-
-      return { error: null };
-    } catch (err) {
-      return { error: err.message || "An unknown error occurred." };
-    }
-  }
-
   requestSkip(force = false) {
     this.sendMessage(
       this.currentComponent,

--- a/app/pages/admin/arrange/[session_id].vue
+++ b/app/pages/admin/arrange/[session_id].vue
@@ -77,32 +77,6 @@ const showHostNameModal = ref(
 );
 const hostNameSubmitting = ref(false);
 
-// Public-quiz host-also-plays support.
-// `public=1` is set by the homepage when a visitor starts a public quiz.
-const isPublicPlay = computed(() => route.query.public === "1");
-const canPlay = ref(false);
-const hostUserPlayedQuiz = ref(null);
-const hostPlayedQuizRequested = ref(false);
-
-// When hosting a public quiz, register the host as a player too. The API allows
-// this for any host of a public quiz; a failure just leaves them host-only.
-const tryEnableHostPlay = async (code) => {
-  if (!isPublicPlay.value || hostPlayedQuizRequested.value || !code) return;
-  hostPlayedQuizRequested.value = true;
-  try {
-    const res = await $fetch(`${apiUrl}/user_played_quizes/${code}`, {
-      method: "POST",
-      credentials: "include",
-    });
-    hostUserPlayedQuiz.value = res?.data?.user_played_quiz || null;
-    canPlay.value = !!hostUserPlayedQuiz.value;
-    if (res?.data?.quiz_title) {
-      setActiveQuizTitle(res.data.quiz_title);
-    }
-  } catch (error) {
-    canPlay.value = false;
-  }
-};
 const quizState = computed(() =>
   isPauseQuiz.value ? app.$Pause : app.$Running
 );
@@ -278,8 +252,6 @@ const handleQuizEvents = async (message) => {
       }
       if (message.data.code !== undefined) {
         invitationCode.value = message.data.code;
-        // Code is now known — register the host as a player if this is a public session.
-        tryEnableHostPlay(message.data.code);
       }
     }
   }
@@ -299,23 +271,6 @@ function handleNetworkEvent(message) {
 
 const startQuiz = () => {
   adminOperationHandler.value.quizStartRequest();
-};
-
-const sendAnswer = async (answers) => {
-  if (!canPlay.value || !hostUserPlayedQuiz.value) return;
-  selectedAnswer.value = 0;
-  const { error } = await adminOperationHandler.value.handleSendAnswer(
-    answers,
-    hostUserPlayedQuiz.value,
-    session_id
-  );
-  if (error) {
-    toast.error(error);
-    return;
-  }
-  if (answers.length > 0) {
-    selectedAnswer.value = answers[0];
-  }
 };
 
 const askSkip = () => {
@@ -347,21 +302,15 @@ const goToScoreboardAfterTerminate = async () => {
   invitationCode.value = undefined;
   removeAllUsers();
   setSession(null);
-  // A guest host who also played gets the podium, then their own player scoreboard —
-  // the admin scoreboard endpoint is Kratos-only and would 401 for them. Registered
-  // hosts keep the admin scoreboard + analytics.
+  // Guest hosts must sign in before accessing the Kratos-protected host scoreboard.
   const isGuestHost = usersStore.getUserData()?.role === "guest-user";
-  if (isGuestHost && canPlay.value && hostUserPlayedQuiz.value) {
-    const playerName = usersStore.getUserData()?.username || "player";
+  const scoreboardPath = `/admin/scoreboard?winner_ui=true&aqi=${session_id}`;
+  if (isGuestHost) {
     return await router.push(
-      `/join/${encodeURIComponent(playerName)}/scoreboard?user_played_quiz=${
-        hostUserPlayedQuiz.value
-      }&host=1&winner_ui=true`
+      `/account/login?returnTo=${encodeURIComponent(scoreboardPath)}`
     );
   }
-  return await router.push(
-    "/admin/scoreboard?winner_ui=true&aqi=" + session_id
-  );
+  return await router.push(scoreboardPath);
 };
 
 const askEndQuiz = () => {
@@ -512,9 +461,7 @@ useSeoMeta({
       v-else-if="currentComponent == 'Question'"
       :data="data"
       :is-admin="true"
-      :can-play="canPlay"
       :quiz-title="quizTitle"
-      @send-answer="sendAnswer"
       @ask-skip="askSkip"
     ></QuizQuestionSpace>
     <QuizScoreSpace

--- a/load-test/tests/user-played-quiz-score-test.js
+++ b/load-test/tests/user-played-quiz-score-test.js
@@ -168,7 +168,7 @@ export class UserPlayedScoreQuizControllerTest extends BaseTest {
     );
 
     check(response, {
-      "Host cannot play their own quiz returns 500": (r) => r.status === 500,
+      "Host cannot play their own quiz returns 403": (r) => r.status === 403,
     });
   }
 


### PR DESCRIPTION
## Summary
- enforce hosts as host-only for every quiz visibility and ownership case
- remove host answer and player-scoreboard paths, and exclude legacy host rows from participant reporting
- redirect guest public hosts through sign-in before the host scoreboard

## Validation
- go test ./...
- npm run lint
- npm test -- --run *(existing unrelated component-test failures)*